### PR TITLE
Fix show current version in docs [skip-ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,7 +47,8 @@ function sed_runner() {
 }
 
 # RTD update
-sed_runner 's/release = ''.*''/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py
+sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
+sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py
 
 # bump rmm
 for FILE in conda/environments/*.yml; do

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,14 @@ project = 'cuxfilter'
 copyright = '2019, NVIDIA'
 author = 'NVIDIA'
 
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = '0.13'
 # The full version, including alpha/beta/rc tags
-release = '0.12'
+release = '0.13.0'
 
 nbsphinx_allow_errors = True
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This is needed so we can have the version number in the docs output and keep it updated between releases