### PR TITLE
[WIP] Layouts Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# cuXfilter 0.15.0 (unreleased)
+ 
+## Improvements
+- PR #157 Layouts Refactor
+
 # cuXfilter 0.14.0 (03 Jun 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## New Features
 
 ## Improvements
-- PR #157 Layouts Refactor
 - PR #158 Add docs build script
+- PR #159 Layouts Refactor
 
 ## Bug Fixes
 

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -82,9 +82,8 @@ class Layout0(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = 1600
-                chart.height = int(round(90 * 1.0)) * 10
+            chart.width = 1600
+            chart.height = 900
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -106,10 +105,10 @@ class Layout1(_LayoutBase):
         for i, chart in enumerate(charts, 1):
             if i == 1:
                 chart.width = 1600
-                chart.height = int(round(90 * 0.66)) * 10
+                chart.height = 600
             elif i == 2:
                 chart.width = 1600
-                chart.height = int(round(90 * 0.33)) * 10
+                chart.height = 300
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -129,12 +128,8 @@ class Layout2(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = 900
-                chart.height = 900
-            elif i == 2:
-                chart.width = 900
-                chart.height = 900
+            chart.width = 900
+            chart.height = 900
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -157,10 +152,7 @@ class Layout3(_LayoutBase):
             if i == 1:
                 chart.width = 900
                 chart.height = 900
-            elif i == 2:
-                chart.width = 800
-                chart.height = 450
-            elif i == 3:
+            elif i in [2, 3]:
                 chart.width = 800
                 chart.height = 450
             chart.chart.sizing_mode = "scale_both"
@@ -181,15 +173,8 @@ class Layout4(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = int(1600 * 0.33)
-                chart.height = int(1600 * 0.33)
-            elif i == 2:
-                chart.width = int(1600 * 0.33)
-                chart.height = int(1600 * 0.33)
-            elif i == 3:
-                chart.width = int(1600 * 0.33)
-                chart.height = int(1600 * 0.33)
+            chart.width = int(1600 / 3)
+            chart.height = int(1600 / 3)
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -212,10 +197,7 @@ class Layout5(_LayoutBase):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
-            elif i == 2:
-                chart.width = 800
-                chart.height = 300
-            elif i == 3:
+            elif i in [2, 3]:
                 chart.width = 800
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
@@ -238,18 +220,8 @@ class Layout6(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = 800
-                chart.height = 450
-            elif i == 2:
-                chart.width = 800
-                chart.height = 450
-            elif i == 3:
-                chart.width = 800
-                chart.height = 450
-            elif i == 4:
-                chart.width = 800
-                chart.height = 450
+            chart.width = 800
+            chart.height = 450
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -273,13 +245,7 @@ class Layout7(_LayoutBase):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
-            elif i == 2:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 3:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 4:
+            elif i in [2, 3, 4]:
                 chart.width = int(1600 / 3)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
@@ -305,16 +271,7 @@ class Layout8(_LayoutBase):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
-            elif i == 2:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 3:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 4:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 5:
+            elif i in [2, 3, 4, 5]:
                 chart.width = int(1600 / 4)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
@@ -341,19 +298,10 @@ class Layout9(_LayoutBase):
             if i == 1:
                 chart.width = 1200
                 chart.height = 600
-            elif i == 2:
+            elif i in [2, 3]:
                 chart.width = int(1600 / 4)
                 chart.height = 300
-            elif i == 3:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 4:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 5:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 6:
+            elif i in [4, 5, 6]:
                 chart.width = int(1600 / 3)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
@@ -376,24 +324,8 @@ class Layout10(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = int(1600 / 3)
-                chart.height = 450
-            elif i == 2:
-                chart.width = int(1600 / 3)
-                chart.height = 450
-            elif i == 3:
-                chart.width = int(1600 / 3)
-                chart.height = 450
-            elif i == 4:
-                chart.width = int(1600 / 3)
-                chart.height = 450
-            elif i == 5:
-                chart.width = int(1600 / 3)
-                chart.height = 450
-            elif i == 6:
-                chart.width = int(1600 / 3)
-                chart.height = 450
+            chart.width = int(1600 / 3)
+            chart.height = 450
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
@@ -414,22 +346,10 @@ class Layout11(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
+            if i in [1, 2]:
                 chart.width = int(1600 / 2)
                 chart.height = 600
-            elif i == 2:
-                chart.width = int(1600 / 2)
-                chart.height = 600
-            elif i == 3:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 4:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 5:
-                chart.width = int(1600 / 4)
-                chart.height = 300
-            elif i == 6:
+            elif i in [3, 4, 5, 6]:
                 chart.width = int(1600 / 4)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
@@ -453,33 +373,8 @@ class Layout12(_LayoutBase):
         charts = [x for x in charts.values() if not is_widget(x)]
 
         for i, chart in enumerate(charts, 1):
-            if i == 1:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 2:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 3:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 4:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 5:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 6:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 7:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 8:
-                chart.width = int(1600 / 3)
-                chart.height = 300
-            elif i == 9:
-                chart.width = int(1600 / 3)
-                chart.height = 300
+            chart.width = int(1600 / 3)
+            chart.height = 300
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -21,7 +21,20 @@ def is_widget(obj):
     return "widget" in obj.chart_type or obj.chart_type == "datasize_indicator"
 
 
-class Layout0:
+class _LayoutBase:
+    def _apply_themes(self, charts, theme):
+        for chart in charts.values():
+            if hasattr(chart, "apply_theme"):
+                chart.apply_theme(theme.chart_properties)
+
+    def _process_widgets(self, charts, widgets):
+        for chart in (x for x in charts.values() if is_widget(x)):
+            chart.chart.sizing_mode = "scale_both"
+            chart.chart.width = 280
+            widgets.append(chart.view())
+
+
+class Layout0(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 0
@@ -37,14 +50,10 @@ class Layout0:
 
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -57,7 +66,7 @@ class Layout0:
         return tmpl
 
 
-class Layout1:
+class Layout1(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 1
@@ -74,14 +83,10 @@ class Layout1:
 
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -105,7 +110,7 @@ class Layout1:
         return tmpl
 
 
-class Layout2:
+class Layout2(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 2
@@ -122,14 +127,10 @@ class Layout2:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -154,7 +155,7 @@ class Layout2:
         return tmpl
 
 
-class Layout3:
+class Layout3(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 3
@@ -171,14 +172,10 @@ class Layout3:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -208,7 +205,7 @@ class Layout3:
         return tmpl
 
 
-class Layout4:
+class Layout4(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 4
@@ -224,14 +221,10 @@ class Layout4:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -261,7 +254,7 @@ class Layout4:
         return tmpl
 
 
-class Layout5:
+class Layout5(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 5
@@ -278,14 +271,10 @@ class Layout5:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -315,7 +304,7 @@ class Layout5:
         return tmpl
 
 
-class Layout6:
+class Layout6(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 6
@@ -333,14 +322,10 @@ class Layout6:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -375,7 +360,7 @@ class Layout6:
         return tmpl
 
 
-class Layout7:
+class Layout7(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 7
@@ -393,14 +378,10 @@ class Layout7:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -435,7 +416,7 @@ class Layout7:
         return tmpl
 
 
-class Layout8:
+class Layout8(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 8
@@ -453,14 +434,10 @@ class Layout8:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -500,7 +477,7 @@ class Layout8:
         return tmpl
 
 
-class Layout9:
+class Layout9(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 9
@@ -519,14 +496,10 @@ class Layout9:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -571,7 +544,7 @@ class Layout9:
         return tmpl
 
 
-class Layout10:
+class Layout10(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 10
@@ -589,14 +562,10 @@ class Layout10:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -641,7 +610,7 @@ class Layout10:
         return tmpl
 
 
-class Layout11:
+class Layout11(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 11
@@ -659,14 +628,10 @@ class Layout11:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
@@ -711,7 +676,7 @@ class Layout11:
         return tmpl
 
 
-class Layout12:
+class Layout12(_LayoutBase):
     def generate_dashboard(self, title, charts, theme):
         """
         layout 12
@@ -730,14 +695,10 @@ class Layout12:
         num_of_charts_added = 0
         widgets = pn.Column()
 
-        for chart in charts.values():
-            if hasattr(chart, "apply_theme"):
-                chart.apply_theme(theme.chart_properties)
-            if is_widget(chart):
-                chart.chart.sizing_mode = "scale_both"
-                chart.chart.width = 280
-                widgets.append(chart.view())
-                continue
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+
+        for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -22,6 +22,8 @@ def is_widget(obj):
 
 
 class _LayoutBase:
+    _layout: str
+
     def _apply_themes(self, charts, theme):
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
@@ -35,13 +37,15 @@ class _LayoutBase:
 
 
 class Layout0(_LayoutBase):
+    _layout = layout_0
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 0
         [1]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_0)
+        tmpl = pn.Template(theme.layout_head + self._layout)
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
         )
@@ -67,6 +71,8 @@ class Layout0(_LayoutBase):
 
 
 class Layout1(_LayoutBase):
+    _layout = layout_1
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 1
@@ -111,6 +117,8 @@ class Layout1(_LayoutBase):
 
 
 class Layout2(_LayoutBase):
+    _layout = layout_2
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 2
@@ -118,7 +126,7 @@ class Layout2(_LayoutBase):
         [1 2]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_2)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -156,6 +164,8 @@ class Layout2(_LayoutBase):
 
 
 class Layout3(_LayoutBase):
+    _layout = layout_3
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 3
@@ -163,7 +173,7 @@ class Layout3(_LayoutBase):
         [1   3]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_3)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -206,13 +216,15 @@ class Layout3(_LayoutBase):
 
 
 class Layout4(_LayoutBase):
+    _layout = layout_4
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 4
         [1 2 3]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_4)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -255,6 +267,8 @@ class Layout4(_LayoutBase):
 
 
 class Layout5(_LayoutBase):
+    _layout = layout_5
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 5
@@ -262,7 +276,7 @@ class Layout5(_LayoutBase):
         [2   3]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_5)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -305,6 +319,8 @@ class Layout5(_LayoutBase):
 
 
 class Layout6(_LayoutBase):
+    _layout = layout_6
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 6
@@ -313,7 +329,7 @@ class Layout6(_LayoutBase):
         [3  4]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_6)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -361,6 +377,8 @@ class Layout6(_LayoutBase):
 
 
 class Layout7(_LayoutBase):
+    _layout = layout_7
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 7
@@ -369,7 +387,7 @@ class Layout7(_LayoutBase):
         [2  3  4]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_7)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -417,6 +435,8 @@ class Layout7(_LayoutBase):
 
 
 class Layout8(_LayoutBase):
+    _layout = layout_8
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 8
@@ -425,7 +445,7 @@ class Layout8(_LayoutBase):
         [2  3   4  5]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_8)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -478,6 +498,8 @@ class Layout8(_LayoutBase):
 
 
 class Layout9(_LayoutBase):
+    _layout = layout_9
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 9
@@ -487,7 +509,7 @@ class Layout9(_LayoutBase):
         [4  5  6]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_9)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -545,6 +567,8 @@ class Layout9(_LayoutBase):
 
 
 class Layout10(_LayoutBase):
+    _layout = layout_10
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 10
@@ -553,7 +577,7 @@ class Layout10(_LayoutBase):
         [4  5  6]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_10)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -611,6 +635,8 @@ class Layout10(_LayoutBase):
 
 
 class Layout11(_LayoutBase):
+    _layout = layout_11
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 11
@@ -619,7 +645,7 @@ class Layout11(_LayoutBase):
         [3   4  5   6]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_11)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
@@ -677,6 +703,8 @@ class Layout11(_LayoutBase):
 
 
 class Layout12(_LayoutBase):
+    _layout = layout_12
+
     def generate_dashboard(self, title, charts, theme):
         """
         layout 12
@@ -686,7 +714,7 @@ class Layout12(_LayoutBase):
         [7  8  9]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_12)
+        tmpl = pn.Template(theme.layout_head + self._layout)
 
         tmpl.add_panel(
             "title", '<div class="nav-title"> ' + str(title) + "</div>"

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -80,17 +80,16 @@ class Layout0(_LayoutBase):
         [1]
         """
 
-        num_charts_added = 0
+        charts = [x for x in charts.values() if not is_widget(x)]
 
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 1.0)) * 10
                 tmpl.add_panel("chart1", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout1(_LayoutBase):
@@ -103,22 +102,21 @@ class Layout1(_LayoutBase):
         [2]
         """
 
-        num_charts_added = 0
+        charts = [x for x in charts.values() if not is_widget(x)]
 
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.66)) * 10
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.33)) * 10
                 tmpl.add_panel("chart2", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout2(_LayoutBase):
@@ -131,21 +129,21 @@ class Layout2(_LayoutBase):
         [1 2]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart2", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout3(_LayoutBase):
@@ -158,26 +156,26 @@ class Layout3(_LayoutBase):
         [1   3]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout4(_LayoutBase):
@@ -189,26 +187,26 @@ class Layout4(_LayoutBase):
         [1 2 3]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart3", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout5(_LayoutBase):
@@ -221,26 +219,26 @@ class Layout5(_LayoutBase):
         [2   3]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout6(_LayoutBase):
@@ -254,31 +252,31 @@ class Layout6(_LayoutBase):
         [3  4]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart4", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout7(_LayoutBase):
@@ -292,31 +290,31 @@ class Layout7(_LayoutBase):
         [2  3  4]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout8(_LayoutBase):
@@ -330,36 +328,36 @@ class Layout8(_LayoutBase):
         [2  3   4  5]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_charts_added == 5:
+            elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout9(_LayoutBase):
@@ -374,41 +372,41 @@ class Layout9(_LayoutBase):
         [4  5  6]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1200
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_charts_added == 5:
+            elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_charts_added == 6:
+            elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout10(_LayoutBase):
@@ -422,41 +420,41 @@ class Layout10(_LayoutBase):
         [4  5  6]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart4", chart.view())
-            elif num_charts_added == 5:
+            elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart5", chart.view())
-            elif num_charts_added == 6:
+            elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart6", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout11(_LayoutBase):
@@ -470,41 +468,41 @@ class Layout11(_LayoutBase):
         [3   4  5   6]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_charts_added == 5:
+            elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_charts_added == 6:
+            elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
 
-        return num_charts_added
+        return len(charts)
 
 
 class Layout12(_LayoutBase):
@@ -519,53 +517,53 @@ class Layout12(_LayoutBase):
         [7  8  9]
         """
 
-        num_charts_added = 0
-        for chart in (x for x in charts.values() if not is_widget(x)):
-            num_charts_added += 1
-            if num_charts_added == 1:
+        charts = [x for x in charts.values() if not is_widget(x)]
+
+        for i, chart in enumerate(charts, 1):
+            if i == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart1", chart.view())
-            elif num_charts_added == 2:
+            elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_charts_added == 3:
+            elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_charts_added == 4:
+            elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_charts_added == 5:
+            elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_charts_added == 6:
+            elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
-            elif num_charts_added == 7:
+            elif i == 7:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart7", chart.view())
-            elif num_charts_added == 8:
+            elif i == 8:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart8", chart.view())
-            elif num_charts_added == 9:
+            elif i == 9:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart9", chart.view())
 
-        return num_charts_added
+        return len(charts)

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -34,20 +34,21 @@ class _LayoutBase:
             "title", '<div class="nav-title"> ' + str(title) + "</div>"
         )
 
-        widgets = pn.Column()
+        widgets = [x for x in charts.values() if is_widget(x)]
+        plots = [x for x in charts.values() if not is_widget(x)]
 
         self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
+        widgetbox = self._process_widgets(widgets)
+        self._process_plots(plots, tmpl)
+        self._pad_missing_plots(len(plots), tmpl)
 
-        num_charts_added = self._process_charts(charts, tmpl)
-
-        self._pad_missing_charts(num_charts_added, tmpl)
-
-        tmpl.add_panel("widgets", widgets)
+        tmpl.add_panel("widgets", widgetbox)
         return tmpl
 
     @property
     def total_charts(self):
+        # Would be nice if the templates and this value could be derived from
+        # some common declarative source description
         return len(self._num_charts_pat.findall(self._layout))
 
     def _apply_themes(self, charts, theme):
@@ -55,54 +56,49 @@ class _LayoutBase:
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
 
-    def _process_widgets(self, charts, widgets):
-        for chart in (x for x in charts.values() if is_widget(x)):
-            chart.chart.width = 280
-            widgets.append(chart.view())
+    def _process_widgets(self, widgets):
+        widgets = pn.Column()
+        for obj in widgets:
+            obj.chart.width = 280
+            widgets.append(obj.view())
 
-    def _pad_missing_charts(self, num_charts_added, tmpl):
+    def _pad_missing_plots(self, num_charts_added, tmpl):
         N = self.total_charts - num_charts_added
 
         for i in range(N, num_charts_added, -1):
             tmpl.add_panel(f"chart{i}", "")
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         raise NotImplementedError()
 
 
 class Layout0(_LayoutBase):
     _layout = layout_0
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 0
         [1]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = 1600
             chart.height = 900
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout1(_LayoutBase):
     _layout = layout_1
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 1
         [1]
         [2]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
@@ -112,43 +108,35 @@ class Layout1(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout2(_LayoutBase):
     _layout = layout_2
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 2
 
         [1 2]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = 900
             chart.height = 900
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout3(_LayoutBase):
     _layout = layout_3
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 3
         [1   2]
         [1   3]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 900
                 chart.height = 900
@@ -158,42 +146,34 @@ class Layout3(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout4(_LayoutBase):
     _layout = layout_4
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 4
         [1 2 3]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = int(1600 / 3)
             chart.height = int(1600 / 3)
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout5(_LayoutBase):
     _layout = layout_5
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 5
         [  1  ]
         [2   3]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
@@ -203,13 +183,11 @@ class Layout5(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout6(_LayoutBase):
     _layout = layout_6
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 6
 
@@ -217,21 +195,17 @@ class Layout6(_LayoutBase):
         [3  4]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = 800
             chart.height = 450
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout7(_LayoutBase):
     _layout = layout_7
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 7
 
@@ -239,9 +213,7 @@ class Layout7(_LayoutBase):
         [2  3  4]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
@@ -251,13 +223,11 @@ class Layout7(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout8(_LayoutBase):
     _layout = layout_8
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 8
 
@@ -265,9 +235,7 @@ class Layout8(_LayoutBase):
         [2  3   4  5]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 1600
                 chart.height = 600
@@ -277,13 +245,11 @@ class Layout8(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout9(_LayoutBase):
     _layout = layout_9
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 9
 
@@ -292,9 +258,7 @@ class Layout9(_LayoutBase):
         [4  5  6]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i == 1:
                 chart.width = 1200
                 chart.height = 600
@@ -307,13 +271,11 @@ class Layout9(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout10(_LayoutBase):
     _layout = layout_10
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 10
 
@@ -321,21 +283,17 @@ class Layout10(_LayoutBase):
         [4  5  6]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = int(1600 / 3)
             chart.height = 450
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout11(_LayoutBase):
     _layout = layout_11
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 11
 
@@ -343,9 +301,7 @@ class Layout11(_LayoutBase):
         [3   4  5   6]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             if i in [1, 2]:
                 chart.width = int(1600 / 2)
                 chart.height = 600
@@ -355,13 +311,11 @@ class Layout11(_LayoutBase):
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
 
-        return len(charts)
-
 
 class Layout12(_LayoutBase):
     _layout = layout_12
 
-    def _process_charts(self, charts, tmpl):
+    def _process_plots(self, plots, tmpl):
         """
         layout 12
 
@@ -370,12 +324,8 @@ class Layout12(_LayoutBase):
         [7  8  9]
         """
 
-        charts = [x for x in charts.values() if not is_widget(x)]
-
-        for i, chart in enumerate(charts, 1):
+        for i, chart in enumerate(plots, 1):
             chart.width = int(1600 / 3)
             chart.height = 300
             chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel(f"chart{i}", chart.view())
-
-        return len(charts)

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -17,6 +17,10 @@ from .layout_templates import (
 )
 
 
+def is_widget(obj):
+    return "widget" in obj.chart_type or obj.chart_type == "datasize_indicator"
+
+
 class Layout0:
     def generate_dashboard(self, title, charts, theme):
         """
@@ -36,10 +40,7 @@ class Layout0:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -76,10 +77,7 @@ class Layout1:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -127,10 +125,7 @@ class Layout2:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -179,10 +174,7 @@ class Layout3:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -235,10 +227,7 @@ class Layout4:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -292,10 +281,7 @@ class Layout5:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -350,10 +336,7 @@ class Layout6:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -413,10 +396,7 @@ class Layout7:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -476,10 +456,7 @@ class Layout8:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -545,10 +522,7 @@ class Layout9:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -618,10 +592,7 @@ class Layout10:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -691,10 +662,7 @@ class Layout11:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())
@@ -765,10 +733,7 @@ class Layout12:
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
                 chart.apply_theme(theme.chart_properties)
-            if (
-                "widget" in chart.chart_type
-                or chart.chart_type == "datasize_indicator"
-            ):
+            if is_widget(chart):
                 chart.chart.sizing_mode = "scale_both"
                 chart.chart.width = 280
                 widgets.append(chart.view())

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -1,3 +1,5 @@
+import re
+
 import panel as pn
 
 from .layout_templates import (
@@ -24,6 +26,8 @@ def is_widget(obj):
 class _LayoutBase:
     _layout: str
 
+    _num_charts_pat = re.compile("roots.chart")
+
     def generate_dashboard(self, title, charts, theme):
         tmpl = pn.Template(theme.layout_head + self._layout)
         tmpl.add_panel(
@@ -34,10 +38,17 @@ class _LayoutBase:
 
         self._apply_themes(charts, theme)
         self._process_widgets(charts, widgets)
-        self._process_charts(charts, tmpl)
+
+        num_charts_added = self._process_charts(charts, tmpl)
+
+        self._pad_missing_charts(num_charts_added, tmpl)
 
         tmpl.add_panel("widgets", widgets)
         return tmpl
+
+    @property
+    def total_charts(self):
+        return len(self._num_charts_pat.findall(self.layout))
 
     def _apply_themes(self, charts, theme):
         for chart in charts.values():
@@ -49,6 +60,12 @@ class _LayoutBase:
             chart.chart.sizing_mode = "scale_both"
             chart.chart.width = 280
             widgets.append(chart.view())
+
+    def _pad_missing_charts(self, num_charts_added, tmpl):
+        N = self.total_charts - num_charts_added
+
+        for i in range(N, num_charts_added, -1):
+            tmpl.add_panel(f"chart{i}", "")
 
     def _process_charts(self, charts, tmpl):
         raise NotImplementedError()
@@ -63,17 +80,19 @@ class Layout0(_LayoutBase):
         [1]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
 
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 1.0)) * 10
                 tmpl.add_panel("chart1", chart.view())
             else:
                 break
+
+        return num_charts_added
 
 
 class Layout1(_LayoutBase):
@@ -86,16 +105,16 @@ class Layout1(_LayoutBase):
         [2]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
 
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.66)) * 10
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.33)) * 10
@@ -103,11 +122,7 @@ class Layout1(_LayoutBase):
             else:
                 break
 
-        n = 2 - num_of_charts_added
-
-        for i in range(n):
-            chart = 2 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout2(_LayoutBase):
@@ -120,15 +135,15 @@ class Layout2(_LayoutBase):
         [1 2]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
@@ -136,11 +151,7 @@ class Layout2(_LayoutBase):
             else:
                 break
 
-        n = 2 - num_of_charts_added
-
-        for i in range(n):
-            chart = 2 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout3(_LayoutBase):
@@ -153,20 +164,20 @@ class Layout3(_LayoutBase):
         [1   3]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
@@ -174,11 +185,7 @@ class Layout3(_LayoutBase):
             else:
                 break
 
-        n = 3 - num_of_charts_added
-
-        for i in range(n):
-            chart = 3 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout4(_LayoutBase):
@@ -190,20 +197,20 @@ class Layout4(_LayoutBase):
         [1 2 3]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
@@ -211,11 +218,7 @@ class Layout4(_LayoutBase):
             else:
                 break
 
-        n = 3 - num_of_charts_added
-
-        for i in range(n):
-            chart = 3 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout5(_LayoutBase):
@@ -228,20 +231,20 @@ class Layout5(_LayoutBase):
         [2   3]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
@@ -249,11 +252,7 @@ class Layout5(_LayoutBase):
             else:
                 break
 
-        n = 3 - num_of_charts_added
-
-        for i in range(n):
-            chart = 3 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout6(_LayoutBase):
@@ -267,25 +266,25 @@ class Layout6(_LayoutBase):
         [3  4]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
@@ -293,11 +292,7 @@ class Layout6(_LayoutBase):
             else:
                 break
 
-        n = 4 - num_of_charts_added
-
-        for i in range(n):
-            chart = 4 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout7(_LayoutBase):
@@ -311,25 +306,25 @@ class Layout7(_LayoutBase):
         [2  3  4]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
@@ -337,11 +332,7 @@ class Layout7(_LayoutBase):
             else:
                 break
 
-        n = 4 - num_of_charts_added
-
-        for i in range(n):
-            chart = 4 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout8(_LayoutBase):
@@ -355,30 +346,30 @@ class Layout8(_LayoutBase):
         [2  3   4  5]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_of_charts_added == 5:
+            elif num_charts_added == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
@@ -386,11 +377,7 @@ class Layout8(_LayoutBase):
             else:
                 break
 
-        n = 5 - num_of_charts_added
-
-        for i in range(n):
-            chart = 5 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout9(_LayoutBase):
@@ -405,35 +392,35 @@ class Layout9(_LayoutBase):
         [4  5  6]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1200
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_of_charts_added == 5:
+            elif num_charts_added == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_of_charts_added == 6:
+            elif num_charts_added == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
@@ -441,11 +428,7 @@ class Layout9(_LayoutBase):
             else:
                 break
 
-        n = 6 - num_of_charts_added
-
-        for i in range(n):
-            chart = 6 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout10(_LayoutBase):
@@ -459,35 +442,35 @@ class Layout10(_LayoutBase):
         [4  5  6]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart4", chart.view())
-            elif num_of_charts_added == 5:
+            elif num_charts_added == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart5", chart.view())
-            elif num_of_charts_added == 6:
+            elif num_charts_added == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
@@ -495,11 +478,7 @@ class Layout10(_LayoutBase):
             else:
                 break
 
-        n = 6 - num_of_charts_added
-
-        for i in range(n):
-            chart = 6 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout11(_LayoutBase):
@@ -513,35 +492,35 @@ class Layout11(_LayoutBase):
         [3   4  5   6]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_of_charts_added == 5:
+            elif num_charts_added == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_of_charts_added == 6:
+            elif num_charts_added == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
@@ -549,11 +528,7 @@ class Layout11(_LayoutBase):
             else:
                 break
 
-        n = 6 - num_of_charts_added
-
-        for i in range(n):
-            chart = 6 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added
 
 
 class Layout12(_LayoutBase):
@@ -568,50 +543,50 @@ class Layout12(_LayoutBase):
         [7  8  9]
         """
 
-        num_of_charts_added = 0
+        num_charts_added = 0
         for chart in (x for x in charts.values() if not is_widget(x)):
-            num_of_charts_added += 1
-            if num_of_charts_added == 1:
+            num_charts_added += 1
+            if num_charts_added == 1:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart1", chart.view())
-            elif num_of_charts_added == 2:
+            elif num_charts_added == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart2", chart.view())
-            elif num_of_charts_added == 3:
+            elif num_charts_added == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            elif num_of_charts_added == 4:
+            elif num_charts_added == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            elif num_of_charts_added == 5:
+            elif num_charts_added == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            elif num_of_charts_added == 6:
+            elif num_charts_added == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
-            elif num_of_charts_added == 7:
+            elif num_charts_added == 7:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart7", chart.view())
-            elif num_of_charts_added == 8:
+            elif num_charts_added == 8:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart8", chart.view())
-            elif num_of_charts_added == 9:
+            elif num_charts_added == 9:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
@@ -619,8 +594,4 @@ class Layout12(_LayoutBase):
             else:
                 break
 
-        n = 9 - num_of_charts_added
-
-        for i in range(n):
-            chart = 9 - i
-            tmpl.add_panel("chart" + str(chart), "")
+        return num_charts_added

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -48,7 +48,7 @@ class _LayoutBase:
 
     @property
     def total_charts(self):
-        return len(self._num_charts_pat.findall(self.layout))
+        return len(self._num_charts_pat.findall(self._layout))
 
     def _apply_themes(self, charts, theme):
         for chart in charts.values():
@@ -85,7 +85,7 @@ class Layout0(_LayoutBase):
             chart.width = 1600
             chart.height = 900
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -110,7 +110,7 @@ class Layout1(_LayoutBase):
                 chart.width = 1600
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -131,7 +131,7 @@ class Layout2(_LayoutBase):
             chart.width = 900
             chart.height = 900
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -156,7 +156,7 @@ class Layout3(_LayoutBase):
                 chart.width = 800
                 chart.height = 450
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -176,7 +176,7 @@ class Layout4(_LayoutBase):
             chart.width = int(1600 / 3)
             chart.height = int(1600 / 3)
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -201,7 +201,7 @@ class Layout5(_LayoutBase):
                 chart.width = 800
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -223,7 +223,7 @@ class Layout6(_LayoutBase):
             chart.width = 800
             chart.height = 450
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -249,7 +249,7 @@ class Layout7(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -275,7 +275,7 @@ class Layout8(_LayoutBase):
                 chart.width = int(1600 / 4)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -305,7 +305,7 @@ class Layout9(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -327,7 +327,7 @@ class Layout10(_LayoutBase):
             chart.width = int(1600 / 3)
             chart.height = 450
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -353,7 +353,7 @@ class Layout11(_LayoutBase):
                 chart.width = int(1600 / 4)
                 chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)
 
@@ -376,6 +376,6 @@ class Layout12(_LayoutBase):
             chart.width = int(1600 / 3)
             chart.height = 300
             chart.chart.sizing_mode = "scale_both"
-            tmpl.add_panel("chart{i}", chart.view())
+            tmpl.add_panel(f"chart{i}", chart.view())
 
         return len(charts)

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -24,6 +24,21 @@ def is_widget(obj):
 class _LayoutBase:
     _layout: str
 
+    def generate_dashboard(self, title, charts, theme):
+        tmpl = pn.Template(theme.layout_head + self._layout)
+        tmpl.add_panel(
+            "title", '<div class="nav-title"> ' + str(title) + "</div>"
+        )
+
+        widgets = pn.Column()
+
+        self._apply_themes(charts, theme)
+        self._process_widgets(charts, widgets)
+        self._process_charts(charts, tmpl)
+
+        tmpl.add_panel("widgets", widgets)
+        return tmpl
+
     def _apply_themes(self, charts, theme):
         for chart in charts.values():
             if hasattr(chart, "apply_theme"):
@@ -35,27 +50,20 @@ class _LayoutBase:
             chart.chart.width = 280
             widgets.append(chart.view())
 
+    def _process_charts(self, charts, tmpl):
+        raise NotImplementedError()
+
 
 class Layout0(_LayoutBase):
     _layout = layout_0
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 0
         [1]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
 
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
@@ -66,31 +74,19 @@ class Layout0(_LayoutBase):
                 tmpl.add_panel("chart1", chart.view())
             else:
                 break
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
 
 
 class Layout1(_LayoutBase):
     _layout = layout_1
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 1
         [1]
         [2]
         """
 
-        tmpl = pn.Template(theme.layout_head + layout_1)
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
 
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
@@ -112,32 +108,19 @@ class Layout1(_LayoutBase):
         for i in range(n):
             chart = 2 - i
             tmpl.add_panel("chart" + str(chart), "")
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
 
 
 class Layout2(_LayoutBase):
     _layout = layout_2
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 2
 
         [1 2]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -159,32 +142,18 @@ class Layout2(_LayoutBase):
             chart = 2 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout3(_LayoutBase):
     _layout = layout_3
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 3
         [1   2]
         [1   3]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -211,31 +180,17 @@ class Layout3(_LayoutBase):
             chart = 3 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout4(_LayoutBase):
     _layout = layout_4
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 4
         [1 2 3]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -262,32 +217,18 @@ class Layout4(_LayoutBase):
             chart = 3 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout5(_LayoutBase):
     _layout = layout_5
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 5
         [  1  ]
         [2   3]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -314,14 +255,11 @@ class Layout5(_LayoutBase):
             chart = 3 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout6(_LayoutBase):
     _layout = layout_6
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 6
 
@@ -329,18 +267,7 @@ class Layout6(_LayoutBase):
         [3  4]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -372,14 +299,11 @@ class Layout6(_LayoutBase):
             chart = 4 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout7(_LayoutBase):
     _layout = layout_7
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 7
 
@@ -387,18 +311,7 @@ class Layout7(_LayoutBase):
         [2  3  4]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -430,14 +343,11 @@ class Layout7(_LayoutBase):
             chart = 4 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout8(_LayoutBase):
     _layout = layout_8
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 8
 
@@ -445,18 +355,7 @@ class Layout8(_LayoutBase):
         [2  3   4  5]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -493,14 +392,11 @@ class Layout8(_LayoutBase):
             chart = 5 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout9(_LayoutBase):
     _layout = layout_9
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 9
 
@@ -509,18 +405,7 @@ class Layout9(_LayoutBase):
         [4  5  6]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -562,14 +447,11 @@ class Layout9(_LayoutBase):
             chart = 6 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout10(_LayoutBase):
     _layout = layout_10
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 10
 
@@ -577,18 +459,7 @@ class Layout10(_LayoutBase):
         [4  5  6]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -630,14 +501,11 @@ class Layout10(_LayoutBase):
             chart = 6 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout11(_LayoutBase):
     _layout = layout_11
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 11
 
@@ -645,18 +513,7 @@ class Layout11(_LayoutBase):
         [3   4  5   6]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -698,14 +555,11 @@ class Layout11(_LayoutBase):
             chart = 6 - i
             tmpl.add_panel("chart" + str(chart), "")
 
-        tmpl.add_panel("widgets", widgets)
-        return tmpl
-
 
 class Layout12(_LayoutBase):
     _layout = layout_12
 
-    def generate_dashboard(self, title, charts, theme):
+    def _process_charts(self, charts, tmpl):
         """
         layout 12
 
@@ -714,18 +568,7 @@ class Layout12(_LayoutBase):
         [7  8  9]
         """
 
-        tmpl = pn.Template(theme.layout_head + self._layout)
-
-        tmpl.add_panel(
-            "title", '<div class="nav-title"> ' + str(title) + "</div>"
-        )
-
         num_of_charts_added = 0
-        widgets = pn.Column()
-
-        self._apply_themes(charts, theme)
-        self._process_widgets(charts, widgets)
-
         for chart in (x for x in charts.values() if not is_widget(x)):
             num_of_charts_added += 1
             if num_of_charts_added == 1:
@@ -781,6 +624,3 @@ class Layout12(_LayoutBase):
         for i in range(n):
             chart = 9 - i
             tmpl.add_panel("chart" + str(chart), "")
-
-        tmpl.add_panel("widgets", widgets)
-        return tmpl

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -57,7 +57,6 @@ class _LayoutBase:
 
     def _process_widgets(self, charts, widgets):
         for chart in (x for x in charts.values() if is_widget(x)):
-            chart.chart.sizing_mode = "scale_both"
             chart.chart.width = 280
             widgets.append(chart.view())
 
@@ -84,9 +83,9 @@ class Layout0(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 1.0)) * 10
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -106,13 +105,12 @@ class Layout1(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.66)) * 10
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.33)) * 10
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -132,13 +130,12 @@ class Layout2(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -158,17 +155,15 @@ class Layout3(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -187,17 +182,15 @@ class Layout4(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -217,17 +210,15 @@ class Layout5(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -248,21 +239,18 @@ class Layout6(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -283,21 +271,18 @@ class Layout7(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -318,25 +303,21 @@ class Layout8(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 5:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -358,29 +339,24 @@ class Layout9(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = 1200
                 chart.height = 600
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 5:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 6:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -401,29 +377,24 @@ class Layout10(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
             elif i == 5:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
             elif i == 6:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -444,29 +415,24 @@ class Layout11(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 5:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
             elif i == 6:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
@@ -488,41 +454,33 @@ class Layout12(_LayoutBase):
 
         for i, chart in enumerate(charts, 1):
             if i == 1:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 2:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 3:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 4:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 5:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 6:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 7:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 8:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
             elif i == 9:
-                chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
+            chart.chart.sizing_mode = "scale_both"
             tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -89,8 +89,6 @@ class Layout0(_LayoutBase):
                 chart.width = 1600
                 chart.height = int(round(90 * 1.0)) * 10
                 tmpl.add_panel("chart1", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -119,8 +117,6 @@ class Layout1(_LayoutBase):
                 chart.width = 1600
                 chart.height = int(round(90 * 0.33)) * 10
                 tmpl.add_panel("chart2", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -148,8 +144,6 @@ class Layout2(_LayoutBase):
                 chart.width = 900
                 chart.height = 900
                 tmpl.add_panel("chart2", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -182,8 +176,6 @@ class Layout3(_LayoutBase):
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart3", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -215,8 +207,6 @@ class Layout4(_LayoutBase):
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
                 tmpl.add_panel("chart3", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -249,8 +239,6 @@ class Layout5(_LayoutBase):
                 chart.width = 800
                 chart.height = 300
                 tmpl.add_panel("chart3", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -289,8 +277,6 @@ class Layout6(_LayoutBase):
                 chart.width = 800
                 chart.height = 450
                 tmpl.add_panel("chart4", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -329,8 +315,6 @@ class Layout7(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart4", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -374,8 +358,6 @@ class Layout8(_LayoutBase):
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart5", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -425,8 +407,6 @@ class Layout9(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -475,8 +455,6 @@ class Layout10(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 450
                 tmpl.add_panel("chart6", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -525,8 +503,6 @@ class Layout11(_LayoutBase):
                 chart.width = int(1600 / 4)
                 chart.height = 300
                 tmpl.add_panel("chart6", chart.view())
-            else:
-                break
 
         return num_charts_added
 
@@ -591,7 +567,5 @@ class Layout12(_LayoutBase):
                 chart.width = int(1600 / 3)
                 chart.height = 300
                 tmpl.add_panel("chart9", chart.view())
-            else:
-                break
 
         return num_charts_added

--- a/python/cuxfilter/layouts/layouts.py
+++ b/python/cuxfilter/layouts/layouts.py
@@ -87,7 +87,7 @@ class Layout0(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 1.0)) * 10
-                tmpl.add_panel("chart1", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -109,12 +109,11 @@ class Layout1(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.66)) * 10
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = int(round(90 * 0.33)) * 10
-                tmpl.add_panel("chart2", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -136,12 +135,11 @@ class Layout2(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
-                tmpl.add_panel("chart2", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -163,17 +161,15 @@ class Layout3(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 900
                 chart.height = 900
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart3", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -194,17 +190,15 @@ class Layout4(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 * 0.33)
                 chart.height = int(1600 * 0.33)
-                tmpl.add_panel("chart3", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -226,17 +220,15 @@ class Layout5(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -259,22 +251,19 @@ class Layout6(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 800
                 chart.height = 450
-                tmpl.add_panel("chart4", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -297,22 +286,19 @@ class Layout7(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart4", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -335,27 +321,23 @@ class Layout8(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1600
                 chart.height = 600
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart4", chart.view())
             elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart5", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -379,32 +361,27 @@ class Layout9(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = 1200
                 chart.height = 600
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart4", chart.view())
             elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart5", chart.view())
             elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart6", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -427,32 +404,27 @@ class Layout10(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart4", chart.view())
             elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart5", chart.view())
             elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 450
-                tmpl.add_panel("chart6", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -475,32 +447,27 @@ class Layout11(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 2)
                 chart.height = 600
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart4", chart.view())
             elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart5", chart.view())
             elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 4)
                 chart.height = 300
-                tmpl.add_panel("chart6", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)
 
@@ -524,46 +491,38 @@ class Layout12(_LayoutBase):
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart1", chart.view())
             elif i == 2:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart2", chart.view())
             elif i == 3:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart3", chart.view())
             elif i == 4:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart4", chart.view())
             elif i == 5:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart5", chart.view())
             elif i == 6:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart6", chart.view())
             elif i == 7:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart7", chart.view())
             elif i == 8:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart8", chart.view())
             elif i == 9:
                 chart.chart.sizing_mode = "scale_both"
                 chart.width = int(1600 / 3)
                 chart.height = 300
-                tmpl.add_panel("chart9", chart.view())
+            tmpl.add_panel("chart{i}", chart.view())
 
         return len(charts)

--- a/python/cuxfilter/tests/layouts/test_layouts.py
+++ b/python/cuxfilter/tests/layouts/test_layouts.py
@@ -1,0 +1,26 @@
+import pytest
+
+# module under test
+import cuxfilter.layouts.layouts as m
+
+
+class _Chart:
+    def __init__(self, chart_type):
+        self.chart_type = chart_type
+
+
+class Test_is_widget:
+    @pytest.mark.parametrize(
+        "chart_type", ["widget", "foo widget", "foo widget bar"]
+    )
+    def test_identifies_widget_in_chart_type(self, chart_type):
+        c = _Chart(chart_type)
+        assert m.is_widget(c)
+
+    def test_identifies_datasize_indicator(self):
+        c = _Chart("datasize_indicator")
+        assert m.is_widget(c)
+
+    def test_identifies_non_widget_otherwise(self):
+        c = _Chart("plot")
+        assert not m.is_widget(c)


### PR DESCRIPTION
Hi @AjayThorve I've tried to split up and arrange the commits in a fairly atomic way, but the new `layouts` module is down to ~300 lines so it might be useful to just refer to the entire new file as well. I tested manually with the available notebooks and with the existing unit tests (more about tests below)

## Current Changes

#### Factor out predicates

I factored the detection of widgets out into a function `is_widget`. My own preferences here are aggressive. It's not an exaggeration to say that once a predicate has an "and" or "or" I'm about ready to pull it into its own function. 

#### Use built-in `enumerate`

Almost always a win to use `enumerate` over manually fiddling with counters

#### Split loops

I know the inclination here is probably towards loop fusion :) But in this case there are only ever single digit numbers of things to loop over, so the logic can be more clearly expressed by not doing multiple things in one big loop. In this case: theme application, widget filtering, and chart templating all happened in one loop. This PR splits out those tasks into their own functions (which could be individually tested), which also affords the next step:

#### NVI pattern

The addition of the base class `_LayoutBase` was to implement the [Non-virtual Interface Pattern](https://en.wikipedia.org/wiki/Non-virtual_interface_pattern). This is a really useful pattern when there are fixed steps that surround some kind of varying steps, as was the case here. Specifically, the theme application, widget handling, and "padding" step are all the same. What varies is just the aspect ratio handling, so that is all that is pulled in to the `_process_plots` method on subclasses. 

It would have also been possible to accomplish this with a decorator but it would be a fairly complicated decorator, so I went with the base class in this case. 

All of the above was somewhat aggressive "factoring out common code" but like to also always remember a main reason it is good to factor out common code actually involves all the code paths that are *not* common, i.e. to make them easier to see and compare 

#### Collapse identical branches

Many of the aspect-ratio computations were identical, so they could be collapsed in to branches that handled any of the relevant plots via `if i in [...]`

## Continuing Ideas

#### Tests

There weren't any existing tests. I am happy to take a poke at adding some, in this PR or in follow up. It would be helpful if there is any existing easy way to manually (e.g. an informal test script) it would be nice to go through that. I tried to make "safe" transformations but there is always the possibility of typos, etc. 

#### Factor Templates

The templates themselves also have a fair amount of duplication. This could be factored out with either text subsitution, or perhaps preferably) actually Jinja template inheritance 

#### More Data-driven

In the ideal case I think it would be possible to define a declarative description for each layout that allows all the following to be derived from a single "source of truth":
* the template itself
* the aspect ratios 

If that was done then even `_process_plots` could be generalized and most of `layouts.py` deleted. That might getting too far in to yak-shaving territory though

---