### PR TITLE
Install dependencies via meta packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #158 Add docs build script
+- PR #160 Install dependencies via meta packages
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,9 +57,14 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install "cudf=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" "rapids-notebook-env=$MINOR_VERSION.*" \
-              "datashader>=0.10.*" "panel=0.6.*" "bokeh=1.*" "geopandas>=0.6.*" "pytest" "libwebp" "pyppeteer" \
-              "jupyter-server-proxy" "pyproj>=2.4.*" "nodejs" "dask-cudf=$MINOR_VERSION.*" "dask-cuda=$MINOR_VERSION.*"
+conda install "cudf=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
+               "dask-cudf=$MINOR_VERSION.*" "dask-cuda=$MINOR_VERSION.*" \
+               "rapids-build-env=$MINOR_VERSION.*" \
+               "rapids-notebook-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env rapids-notebook-env
+# conda install "your-pkg=1.0.0"
 
 logger "Check versions..."
 python --version


### PR DESCRIPTION
Install dependencies via `rapids-build-env` and `rapids-notebook-env` (which are pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/

Depends on https://github.com/rapidsai/integration/pull/49