### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -4,8 +4,8 @@
 # cuxfilter CHANGELOG Tester #
 #########################
 
-# Checkout master for comparison
-git checkout --quiet master
+# Checkout main for comparison
+git checkout --quiet main
 
 # Switch back to tip of PR branch
 git checkout --quiet current-pr-branch
@@ -14,7 +14,7 @@ git checkout --quiet current-pr-branch
 set +e
 
 # Get list of modified files between matster and PR branch
-CHANGELOG=`git diff --name-only master...current-pr-branch | grep CHANGELOG.md`
+CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`
 RETVAL=0

--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -6,11 +6,9 @@ set -e
 
 export CUXFILTER_FILE=`conda build conda/recipes/cuxfilter --python=$PYTHON --output`
 
-SOURCE_BRANCH=master
 CUDA_REL=${CUDA_VERSION%.*}
 
-# Restrict uploads to master branch
-if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+if [ ${BUILD_MODE} != "branch" ]; then
   echo "Skipping upload"
   return 0
 fi


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.