### PR TITLE
add lasso selection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuXfilter 0.16.0 (Date TBD)
 
 ## New Features
+- PR #177 Add support for lasso selections
 
 ## Improvements
 - PR #191 Update doc build script for CI

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,6 +59,7 @@ logger "Activate conda env..."
 source activate gdf
 conda install "cudf=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
                "cugraph=$MINOR_VERSION.*" \
+               "cuspatial=$MINOR_VERSION.*" \
                "dask-cudf=$MINOR_VERSION.*" "dask-cuda=$MINOR_VERSION.*" \
                "numba>=0.51.2" \
                "rapids-build-env=$MINOR_VERSION.*" \

--- a/conda/environments/cuxfilter_dev_cuda10.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.0.yml
@@ -7,6 +7,7 @@ channels:
 - anaconda
 dependencies:
 - cupy>=6*
+- cuspatial>=0.15
 - python>=3.6,<3.8
 - cudf=0.16
 - dask>=2.12.0
@@ -25,6 +26,7 @@ dependencies:
 - nodejs
 - recommonmark
 - pytest
+- mock
 - sphinx
 - sphinx_rtd_theme
 - jupyter_sphinx

--- a/conda/environments/cuxfilter_dev_cuda10.1.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.1.yml
@@ -7,6 +7,7 @@ channels:
 - anaconda
 dependencies:
 - cupy>=6*
+- cuspatial>=0.15
 - python>=3.6,<3.8
 - cudf=0.16
 - dask>=2.12.0
@@ -25,6 +26,7 @@ dependencies:
 - nodejs
 - recommonmark
 - pytest
+- mock
 - sphinx
 - sphinx_rtd_theme
 - jupyter_sphinx

--- a/conda/environments/cuxfilter_dev_cuda10.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.2.yml
@@ -8,6 +8,7 @@ channels:
 - anaconda
 dependencies:
 - cupy>=6*
+- cuspatial>=0.15
 - python>=3.6,<3.8
 - cudf=0.16
 - dask>=2.12.0
@@ -26,6 +27,7 @@ dependencies:
 - nodejs
 - recommonmark
 - pytest
+- mock
 - sphinx
 - sphinx_rtd_theme
 - jupyter_sphinx

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -1,4 +1,4 @@
-# name: cudf_dev10.0
+# name: cudf_dev11.0
 channels:
 - rapidsai
 - rapidsai-nightly
@@ -22,7 +22,7 @@ dependencies:
 - pandoc=<2.0.0
 - bokeh>=2.1.1
 - panel
-- cudatoolkit=10.0
+- cudatoolkit=11.0
 - nodejs
 - recommonmark
 - pytest

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   run:
     - python
     - cudf {{ minor_version }}
+    - cuspatial {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
     - datashader >=0.11.1

--- a/python/cuxfilter/charts/core/non_aggregate/core_graph.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_graph.py
@@ -213,13 +213,28 @@ class BaseGraph(BaseChart):
 
         """
 
-        def selection_callback(xmin, xmax, ymin, ymax):
-            if dashboard_cls._active_view != self.name:
-                # reset previous active view and
-                # set current chart as active view
-                dashboard_cls._reset_current_view(new_active_view=self)
-                self.nodes = dashboard_cls._cuxfilter_df.data
+        def lasso_callback(xs, ys):
+            indices = cuspatial.point_in_polygon(
+                self.nodes[self.node_x],
+                self.nodes[self.node_y],
+                cudf.Series([0], index=['selection']),
+                [0],
+                xs, 
+                ys
+            )
+            temp_data = self.source[indices.selection] 
+            node_ids = temp_data[self.node_id]
 
+            nodes, edges = self.query_graph(node_ids, self.nodes, self.edges)
+
+            # reload all charts with new queried data (cudf.DataFrame only)
+            dashboard_cls._reload_charts(data=nodes, ignore_cols=[self.name])
+
+            # reload graph chart separately as it has an extra edges argument
+            self.reload_chart(nodes=nodes, edges=edges, patch_update=False)
+            del temp_data, nodes, edges
+
+        def box_callback(xmin, xmax, ymin, ymax):
             self.x_range = (xmin, xmax)
             self.y_range = (ymin, ymax)
 
@@ -238,10 +253,10 @@ class BaseGraph(BaseChart):
             )
 
             dashboard_cls._query_str_dict[self.name] = query
-
-            node_ids = dashboard_cls._query(
+            temp_data = dashboard_cls._query(
                 dashboard_cls._generate_query_str()
-            )[self.node_id]
+            )
+            node_ids = temp_data[self.node_id]
 
             nodes, edges = self.query_graph(node_ids, self.nodes, self.edges)
 
@@ -250,7 +265,23 @@ class BaseGraph(BaseChart):
 
             # reload graph chart separately as it has an extra edges argument
             self.reload_chart(nodes=nodes, edges=edges, patch_update=False)
-            del nodes, edges
+            del temp_data, nodes, edges
+
+        def selection_callback(event):
+            if dashboard_cls._active_view != self.name:
+                # reset previous active view and
+                # set current chart as active view
+                dashboard_cls._reset_current_view(new_active_view=self)
+                self.source = dashboard_cls._cuxfilter_df.data
+
+            if event.geometry["type"] == "rect":
+                xmin, xmax = event.geometry["x0"], event.geometry["x1"]
+                ymin, ymax = event.geometry["y0"], event.geometry["y1"]
+                box_callback(xmin, xmax, ymin, ymax)
+            elif event.geometry["type"] == "poly" and event.final:
+                xs = event.geometry["x"]
+                ys = event.geometry["y"]
+                lasso_callback(xs, ys)
 
         return selection_callback
 

--- a/python/cuxfilter/charts/core/non_aggregate/core_graph.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_graph.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 import dask_cudf
 import cudf
+import cuspatial
 import dask.dataframe as dd
 
 from ..core_chart import BaseChart

--- a/python/cuxfilter/charts/core/non_aggregate/core_graph.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_graph.py
@@ -217,12 +217,12 @@ class BaseGraph(BaseChart):
             indices = cuspatial.point_in_polygon(
                 self.nodes[self.node_x],
                 self.nodes[self.node_y],
-                cudf.Series([0], index=['selection']),
+                cudf.Series([0], index=["selection"]),
                 [0],
-                xs, 
-                ys
+                xs,
+                ys,
             )
-            temp_data = self.source[indices.selection] 
+            temp_data = self.source[indices.selection]
             node_ids = temp_data[self.node_id]
 
             nodes, edges = self.query_graph(node_ids, self.nodes, self.edges)

--- a/python/cuxfilter/charts/core/non_aggregate/core_non_aggregate.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_non_aggregate.py
@@ -1,4 +1,6 @@
 from typing import Tuple
+import cudf
+import cuspatial
 import dask_cudf
 import dask.dataframe as dd
 
@@ -81,13 +83,26 @@ class BaseNonAggregate(BaseChart):
 
         """
 
-        def selection_callback(xmin, xmax, ymin, ymax):
-            if dashboard_cls._active_view != self.name:
-                # reset previous active view and
-                # set current chart as active view
-                dashboard_cls._reset_current_view(new_active_view=self)
-                self.source = dashboard_cls._cuxfilter_df.data
+        def lasso_callback(xs, ys):
+            indices = cuspatial.point_in_polygon(
+                self.source[self.x],
+                self.source[self.y],
+                cudf.Series([0], index=['selection']),
+                [0],
+                xs, 
+                ys
+            )
+            temp_data = self.source[indices.selection] 
 
+            # reload all charts with new queried data (cudf.DataFrame only)
+            dashboard_cls._reload_charts(
+                data=temp_data, ignore_cols=[self.name]
+            )
+            self.reload_chart(temp_data, False)
+            del temp_data
+            del indices
+
+        def box_callback(xmin, xmax, ymin, ymax):
             self.x_range = (xmin, xmax)
             self.y_range = (ymin, ymax)
 
@@ -116,6 +131,22 @@ class BaseNonAggregate(BaseChart):
             )
             self.reload_chart(temp_data, False)
             del temp_data
+
+        def selection_callback(event):
+            if dashboard_cls._active_view != self.name:
+                # reset previous active view and
+                # set current chart as active view
+                dashboard_cls._reset_current_view(new_active_view=self)
+                self.source = dashboard_cls._cuxfilter_df.data
+
+            if event.geometry["type"] == "rect":
+                xmin, xmax = event.geometry["x0"], event.geometry["x1"]
+                ymin, ymax = event.geometry["y0"], event.geometry["y1"]
+                box_callback(xmin, xmax, ymin, ymax)
+            elif event.geometry["type"] == "poly" and event.final:
+                xs = event.geometry["x"]
+                ys = event.geometry["y"]
+                lasso_callback(xs, ys)
 
         return selection_callback
 

--- a/python/cuxfilter/charts/core/non_aggregate/core_non_aggregate.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_non_aggregate.py
@@ -87,12 +87,12 @@ class BaseNonAggregate(BaseChart):
             indices = cuspatial.point_in_polygon(
                 self.source[self.x],
                 self.source[self.y],
-                cudf.Series([0], index=['selection']),
+                cudf.Series([0], index=["selection"]),
                 [0],
-                xs, 
-                ys
+                xs,
+                ys,
             )
-            temp_data = self.source[indices.selection] 
+            temp_data = self.source[indices.selection]
 
             # reload all charts with new queried data (cudf.DataFrame only)
             dashboard_cls._reload_charts(

--- a/python/cuxfilter/charts/core/non_aggregate/core_stacked_line.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_stacked_line.py
@@ -136,7 +136,9 @@ class BaseStackedLine(BaseChart):
 
         """
 
-        def selection_callback(xmin, xmax, ymin, ymax):
+        def selection_callback(event):
+            xmin, xmax = event.geometry["x0"], event.geometry["x1"]
+            ymin, ymax = event.geometry["y0"], event.geometry["y1"]
             if dashboard_cls._active_view != self.name:
                 # reset previous active view and
                 # set current chart as active view

--- a/python/cuxfilter/charts/datashader/plots.py
+++ b/python/cuxfilter/charts/datashader/plots.py
@@ -26,6 +26,7 @@ from bokeh.plotting import figure
 from bokeh.models import (
     BoxSelectTool,
     ColorBar,
+    LassoSelectTool,
     LinearColorMapper,
     LogColorMapper,
     BasicTicker,
@@ -278,6 +279,7 @@ class Scatter(BaseScatter):
         )
 
         self.chart.add_tools(BoxSelectTool())
+        self.chart.add_tools(LassoSelectTool())
 
         self.tile_provider = _get_provider(self.tile_provider)
         if self.tile_provider is not None:
@@ -346,12 +348,7 @@ class Scatter(BaseScatter):
         Ouput:
         """
 
-        def temp_callback(event):
-            xmin, xmax = event.geometry["x0"], event.geometry["x1"]
-            ymin, ymax = event.geometry["y0"], event.geometry["y1"]
-            callback(xmin, xmax, ymin, ymax)
-
-        self.chart.on_event(events.SelectionGeometry, temp_callback)
+        self.chart.on_event(events.SelectionGeometry, callback)
 
     def apply_theme(self, properties_dict):
         """
@@ -813,12 +810,7 @@ class Graph(BaseGraph):
         Ouput:
         """
 
-        def temp_callback(event):
-            xmin, xmax = event.geometry["x0"], event.geometry["x1"]
-            ymin, ymax = event.geometry["y0"], event.geometry["y1"]
-            callback(xmin, xmax, ymin, ymax)
-
-        self.chart.on_event(events.SelectionGeometry, temp_callback)
+        self.chart.on_event(events.SelectionGeometry, callback)
 
     def apply_theme(self, properties_dict):
         """
@@ -1064,12 +1056,7 @@ class Line(BaseLine):
         Ouput:
         """
 
-        def temp_callback(event):
-            xmin, xmax = event.geometry["x0"], event.geometry["x1"]
-            ymin, ymax = event.geometry["y0"], event.geometry["y1"]
-            callback(xmin, xmax, ymin, ymax)
-
-        self.chart.on_event(events.SelectionGeometry, temp_callback)
+        self.chart.on_event(events.SelectionGeometry, callback)
 
     def apply_theme(self, properties_dict):
         """
@@ -1339,12 +1326,7 @@ class StackedLines(BaseStackedLine):
         Ouput:
         """
 
-        def temp_callback(event):
-            xmin, xmax = event.geometry["x0"], event.geometry["x1"]
-            ymin, ymax = event.geometry["y0"], event.geometry["y1"]
-            callback(xmin, xmax, ymin, ymax)
-
-        self.chart.on_event(events.SelectionGeometry, temp_callback)
+        self.chart.on_event(events.SelectionGeometry, callback)
 
     def apply_theme(self, properties_dict):
         """

--- a/python/cuxfilter/charts/datashader/plots.py
+++ b/python/cuxfilter/charts/datashader/plots.py
@@ -734,6 +734,7 @@ class Graph(BaseGraph):
         self.display_edges.on_change("_active", cb)
 
         self.chart.add_tools(BoxSelectTool())
+        self.chart.add_tools(LassoSelectTool())
         self.chart.add_tools(self.inspect_neighbors)
         self.chart.add_tools(self.display_edges)
 

--- a/python/cuxfilter/tests/charts/core/test_core_graph.py
+++ b/python/cuxfilter/tests/charts/core/test_core_graph.py
@@ -107,6 +107,7 @@ class TestCoreGraph:
 
         class evt:
             geometry = dict(x0=1, x1=3, y0=0, y1=1, type="rect")
+
         t = bg.get_selection_geometry_callback(dashboard)
         t(evt)
         assert self.result.equals(result)
@@ -138,7 +139,9 @@ class TestCoreGraph:
         t = bg.get_selection_geometry_callback(dashboard)
         with mock.patch("cuspatial.point_in_polygon") as pip:
 
-            pip.return_value = cudf.DataFrame({"selection": [True, False, True, False]}) 
+            pip.return_value = cudf.DataFrame(
+                {"selection": [True, False, True, False]}
+            )
             t(evt)
             assert pip.called
 

--- a/python/cuxfilter/tests/charts/core/test_core_graph.py
+++ b/python/cuxfilter/tests/charts/core/test_core_graph.py
@@ -1,5 +1,6 @@
 import pytest
 import cudf
+import mock
 
 from cuxfilter.charts.core.non_aggregate.core_graph import BaseGraph
 from cuxfilter.dashboard import DashBoard
@@ -81,7 +82,7 @@ class TestCoreGraph:
             ),
         ],
     )
-    def test_selection_callback(self, inspect_neighbors, result):
+    def test_box_selection_callback(self, inspect_neighbors, result):
         nodes = cudf.DataFrame(
             {"vertex": [0, 1, 2, 3], "x": [0, 1, 1, 2], "y": [0, 1, 2, 0]}
         )
@@ -104,9 +105,42 @@ class TestCoreGraph:
 
         dashboard._active_view = bg.name
 
+        class evt:
+            geometry = dict(x0=1, x1=3, y0=0, y1=1, type="rect")
         t = bg.get_selection_geometry_callback(dashboard)
-        t(xmin=1, xmax=3, ymin=0, ymax=1)
+        t(evt)
         assert self.result.equals(result)
+
+    def test_lasso_election_callback(self):
+        nodes = cudf.DataFrame(
+            {"vertex": [0, 1, 2, 3], "x": [0, 1, 1, 2], "y": [0, 1, 2, 0]}
+        )
+        edges = cudf.DataFrame(
+            {"source": [1, 1, 1, 1], "target": [0, 1, 2, 3]}
+        )
+        dashboard = DashBoard(dataframe=DataFrame.load_graph((nodes, edges)))
+
+        bg = BaseGraph()
+        bg.chart_type = "temp"
+        bg.nodes = nodes
+        bg.edges = edges
+        bg.inspect_neighbors = CustomInspectTool(_active=False)
+
+        def t_function(nodes, edges=None, patch_update=False):
+            pass
+
+        bg.reload_chart = t_function
+
+        class evt:
+            geometry = dict(x=[1, 1, 2], y=[1, 2, 1], type="poly")
+            final = True
+
+        t = bg.get_selection_geometry_callback(dashboard)
+        with mock.patch("cuspatial.point_in_polygon") as pip:
+
+            pip.return_value = cudf.DataFrame({"selection": [True, False, True, False]}) 
+            t(evt)
+            assert pip.called
 
     @pytest.mark.parametrize(
         "x_range, y_range, query",

--- a/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
+++ b/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
@@ -114,9 +114,7 @@ class TestCoreNonAggregateChart:
         bnac = BaseNonAggregate()
         bnac.x = "a"
         bnac.y = "b"
-        bnac.source = dict(a=[], b=[], s=[])
         bnac.chart_type = "temp"
-        self.result = None
 
         def t_function(data, patch_update=False):
             self.result = data
@@ -125,8 +123,6 @@ class TestCoreNonAggregateChart:
         df = cudf.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5]})
         dashboard = DashBoard(dataframe=DataFrame.from_dataframe(df))
 
-        dashboard._active_view = bnac.name
-
         class evt:
             geometry = dict(x=[1, 1, 2], y=[1, 2, 1], type="poly")
             final = True
@@ -134,10 +130,7 @@ class TestCoreNonAggregateChart:
         t = bnac.get_selection_geometry_callback(dashboard)
         with mock.patch("cuspatial.point_in_polygon") as pip:
 
-            class _indices:
-                selection = "s"
-
-            pip.return_value = _indices
+            pip.return_value = cudf.DataFrame({"selection": [True, False, True]}) 
             t(evt)
             assert pip.called
 

--- a/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
+++ b/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
@@ -130,7 +130,9 @@ class TestCoreNonAggregateChart:
         t = bnac.get_selection_geometry_callback(dashboard)
         with mock.patch("cuspatial.point_in_polygon") as pip:
 
-            pip.return_value = cudf.DataFrame({"selection": [True, False, True]}) 
+            pip.return_value = cudf.DataFrame(
+                {"selection": [True, False, True]}
+            )
             t(evt)
             assert pip.called
 

--- a/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
+++ b/python/cuxfilter/tests/charts/core/test_core_non_aggregate.py
@@ -128,13 +128,15 @@ class TestCoreNonAggregateChart:
         dashboard._active_view = bnac.name
 
         class evt:
-            geometry = dict(x=[1,1,2], y=[1,2,1], type="poly")
+            geometry = dict(x=[1, 1, 2], y=[1, 2, 1], type="poly")
             final = True
 
         t = bnac.get_selection_geometry_callback(dashboard)
         with mock.patch("cuspatial.point_in_polygon") as pip:
+
             class _indices:
                 selection = "s"
+
             pip.return_value = _indices
             t(evt)
             assert pip.called

--- a/python/cuxfilter/tests/charts/core/test_core_stacked_line.py
+++ b/python/cuxfilter/tests/charts/core/test_core_stacked_line.py
@@ -90,8 +90,10 @@ class TestBaseStackedLine:
         bsl = BaseStackedLine("key", ["val"])
         bsl.chart_type = "stacked_lines"
         self.dashboard._active_view = bsl.name
+
         class evt:
             geometry = dict(x0=1, x1=2, y0=3, y1=4, type="rect")
+
         t = bsl.get_selection_geometry_callback(self.dashboard)
         t(evt)
 

--- a/python/cuxfilter/tests/charts/core/test_core_stacked_line.py
+++ b/python/cuxfilter/tests/charts/core/test_core_stacked_line.py
@@ -86,12 +86,14 @@ class TestBaseStackedLine:
             type(bsl.get_selection_geometry_callback(self.dashboard))
         )
 
-    def test_selection_callback(self):
+    def test_box_selection_callback(self):
         bsl = BaseStackedLine("key", ["val"])
         bsl.chart_type = "stacked_lines"
         self.dashboard._active_view = bsl.name
+        class evt:
+            geometry = dict(x0=1, x1=2, y0=3, y1=4, type="rect")
         t = bsl.get_selection_geometry_callback(self.dashboard)
-        t(xmin=1, xmax=2, ymin=3, ymax=4)
+        t(evt)
 
         assert (
             self.dashboard._query_str_dict["key_stacked_lines"]


### PR DESCRIPTION
cc @AjayThorve 

I reworked my original approach to this. At first, I had modified `get_selection_geometry_callback` to be `get_selection_geometry_callbackS` (plural) and had it return a list of callbacks to downstream consumers. This preserves the flexibility of those intermediate `temp_callback` wrappers. However, this broke quite a bit in testing and elsewhere and I was not quite confident in some of the chain of changes I had to start making. 

The current PR pushes the event itself upstream and to the `selection_callback` directly (and eliminating the intermediate `temp_callback`  functions). Then the `selection_callback` does the switching between rect and lasso events. This significantly limits the scope of changes, at the cost of some flexibility in principle. However I note that all of the current `temp_callback`s were identical, so this flexibility was not used in practice. 

I'd advocate for this approach for now, and if circumstances in the future actually warrant, moving to a more generic approach. 

I did test this with the NYC notebook but any guidance around testing (or the code itself) would be appreciated. 