### PR TITLE
Remove conda installs from doc build script [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #191 Update doc build script for CI
 
 ## Bug Fixes
 - PR #190 fix conflicts related to auto-merge with branch-0.15

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -26,9 +26,6 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate rapids
-# TODO: Move installs to docs-build-env meta package
-conda install -c anaconda markdown beautifulsoup4 jq
-pip install sphinx-markdown-tables
 
 
 logger "Check versions..."


### PR DESCRIPTION
This PR removes the conda installs from the CI doc build script since they are now all listed in the `rapids-doc-env` package in the integration repo ([src](https://github.com/rapidsai/integration/blob/branch-0.16/conda/recipes/rapids-doc-env/meta.yaml)).

Depends on https://github.com/rapidsai/integration/pull/129