### PR TITLE
FIX Update minimum `nodejs` version due to CVE [skip ci changelog]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuXfilter 0.16.0 (Date TBD)
+# cuXfilter 0.16.0 (21 Oct 2020)
 
 ## New Features
 - PR #177 Add support for lasso selections

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -62,6 +62,7 @@ conda install "cudf=$MINOR_VERSION.*" "cudatoolkit=$CUDA_REL" \
                "cuspatial=$MINOR_VERSION.*" \
                "dask-cudf=$MINOR_VERSION.*" "dask-cuda=$MINOR_VERSION.*" \
                "numba>=0.51.2" \
+               "nodejs>=14.9.0" \
                "rapids-build-env=$MINOR_VERSION.*" \
                "rapids-notebook-env=$MINOR_VERSION.*"
 

--- a/conda/environments/cuxfilter_dev_cuda10.1.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.1.yml
@@ -23,7 +23,7 @@ dependencies:
 - bokeh>=2.1.1
 - panel
 - cudatoolkit=10.1
-- nodejs
+- nodejs>=14.9.0
 - recommonmark
 - pytest
 - mock

--- a/conda/environments/cuxfilter_dev_cuda10.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.2.yml
@@ -24,7 +24,7 @@ dependencies:
 - bokeh>=2.1.1
 - panel
 - cudatoolkit=10.2
-- nodejs
+- nodejs>=14.9.0
 - recommonmark
 - pytest
 - mock

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -23,7 +23,7 @@ dependencies:
 - bokeh>=2.1.1
 - panel
 - cudatoolkit=11.0
-- nodejs
+- nodejs>=14.9.0
 - recommonmark
 - pytest
 - mock

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - bokeh >=2.1.1
     - pyproj  >=2.4.*
     - geopandas >=0.6.*
-    - nodejs
+    - nodejs >=14.9.0
     - libwebp
     - pyppeteer
     - jupyter-server-proxy


### PR DESCRIPTION
Forces install of `>=14.9.0` which has an updated patch for `dot-prop` to resolve [CVE-2020-8116](https://github.com/advisories/GHSA-ff7x-qrg7-qggm)