### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ CMake:
  - '**/CMakeLists.txt'
  - '**/cmake/**'
 
-ci:
+gpuCI:
    - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,5 +12,5 @@ gpuCI:
 conda:
    - 'conda/**'
  
- doc:
+doc:
    - 'docs/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,20 +6,15 @@ Python:
  - 'python/**'
  - 'notebooks/**'
 
-libcuxfilter:
+cpp:
  - 'cpp/**'
 
 CMake:
  - '**/CMakeLists.txt'
  - '**/cmake/**'
 
-Java:
- - 'java/**'
+ci:
+   - 'ci/**'
 
-Ops:
- - '.github/**'
- - 'ci/**'
- - 'conda/**'
- - '**/Dockerfile'
- - '**/.dockerignore'
- - 'docker/**'
+conda:
+   - 'conda/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,3 +11,6 @@ gpuCI:
 
 conda:
    - 'conda/**'
+ 
+ doc:
+   - 'docs/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,13 +6,6 @@ Python:
  - 'python/**'
  - 'notebooks/**'
 
-cpp:
- - 'cpp/**'
-
-CMake:
- - '**/CMakeLists.txt'
- - '**/cmake/**'
-
 gpuCI:
    - 'ci/**'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,25 @@
 # https://github.com/actions/labeler#common-examples
-# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Adapted from https://github.com/rapidsai/cuxfilter/blob/main/.github/CODEOWNERS
 # Labels culled from https://github.com/rapidsai/cuxfilter/labels
 
 Python:
- - python/**
- - notebooks/**
+ - 'python/**'
+ - 'notebooks/**'
 
 libcuxfilter:
- - cpp/**
+ - 'cpp/**'
 
 CMake:
- - **/CMakeLists.txt
- - **/cmake/**
+ - '**/CMakeLists.txt'
+ - '**/cmake/**'
 
 Java:
- - java/**
+ - 'java/**'
 
 Ops:
- - .github/**
- - /ci/**
- - conda/**
- - **/Dockerfile
- - **/.dockerignore
- - docker/**
+ - '.github/**'
+ - 'ci/**'
+ - 'conda/**'
+ - '**/Dockerfile'
+ - '**/.dockerignore'
+ - 'docker/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+ triage:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: actions/labeler@main
+     with:
+       repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).