### PR TITLE
Update cupy to >= 7.8

### DIFF
--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2020, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
@@ -30,7 +30,7 @@ requirements:
     - dask-cuda {{ minor_version }}
     - datashader >=0.11.1, <0.12
     - numba >=0.51.2
-    - cupy  >7.1.0,<9.0.0a0
+    - cupy  >=7.8.0,<9.0.0a0
     - panel>=0.9.1, <=0.9.7
     - bokeh >=2.1.1,<=2.2.3
     - pyproj >=2.4, <=2.6.1.post1


### PR DESCRIPTION
PR to update CuPy to version 7.8 to keep versions in sync (cuML requires 7.8 as of https://github.com/rapidsai/cuml/pull/3378 due to usage of cupy.full order parameter) and corresponds to integration PR https://github.com/rapidsai/integration/pull/208

cc @ajschmidt8 