### PR TITLE
Pin Node version

### DIFF
--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - bokeh >=2.1.1,<=2.2.3
     - pyproj >=2.4, <=2.6.1.post1
     - geopandas >=0.6, <=0.8.1
-    - nodejs
+    - nodejs >=12,<15
     - libwebp
     - pyppeteer <=0.2.2
     - jupyter-server-proxy


### PR DESCRIPTION
This PR is related to https://github.com/rapidsai/integration/pull/213.

Lately we've been seeing a lot of `conda` solve issues with NodeJS version 15 (see screenshots below). The solve problems add an extra ~20 minutes to CI jobs. This PR pins the Node version so that it only uses 12-14 (for reference, [14 is the current LTS](https://nodejs.org/en/)). Hopefully this helps with the `conda` conflicts.

![image](https://user-images.githubusercontent.com/7400326/107670066-614c9080-6c60-11eb-9d9b-f4d5bfccc25f.png)

![image](https://user-images.githubusercontent.com/7400326/107670117-690c3500-6c60-11eb-95e3-531771a0ef77.png)
