### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - bokeh >=2.1.1,<=2.2.3
     - pyproj >=2.4, <=2.6.1.post1
     - geopandas >=0.6, <=0.8.1
-    - nodejs
+    - nodejs >=12,<15
     - libwebp
     - pyppeteer <=0.2.2
     - jupyter-server-proxy


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.