### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
-# 0.18.0
+# cuXfilter 0.18.0 (24 Feb 2021)
 
-Please see https://github.com/rapidsai/cuxfilter/releases/tag/branch-0.18-latest for the latest changes to this development branch.
+## Bug Fixes 🐛
+
+- Add static html (#238) @AjayThorve
+
+## Documentation 📖
+
+- Update docs (#236) @AjayThorve
+
+## Improvements 🛠️
+
+- Update stale GHA with exemptions &amp; new labels (#247) @mike-wendt
+- Add GHA to mark issues/prs as stale/rotten (#244) @Ethyling
+- Pin Node version (#239) @ajschmidt8
+- fix state preserving issue for lasso-select callbacks (#231) @AjayThorve
+- Prepare Changelog for Automation (#229) @ajschmidt8
+- New charts - Number &amp; Card (#228) @AjayThorve
+- Refactor themes (#227) @AjayThorve
+- Updated templates using Panel template + React-grid-layout (#226) @AjayThorve
+- Auto-label PRs based on their content (#223) @jolorunyomi
+- Fix forward-merger conflicts for #218 (#221) @ajschmidt8
+- Branch 0.18 merge 0.17 - fix auto merge conflicts (#219) @AjayThorve
 
 # cuXfilter 0.17.0 (10 Dec 2020)
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.