### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
-# cuXfilter 0.19.0 (Date TBD)
+# cuXfilter 0.19.0 (21 Apr 2021)
 
-Please see https://github.com/rapidsai/cuxfilter/releases/tag/v0.19.0a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Bug fix ([#261](https://github.com//rapidsai/cuxfilter/pull/261)) [@AjayThorve](https://github.com/AjayThorve)
+- Bug fixes ([#257](https://github.com//rapidsai/cuxfilter/pull/257)) [@AjayThorve](https://github.com/AjayThorve)
+
+## 📖 Documentation
+
+- Fea/sidebar api change ([#262](https://github.com//rapidsai/cuxfilter/pull/262)) [@AjayThorve](https://github.com/AjayThorve)
+- Auto-merge branch-0.18 to branch-0.19 ([#237](https://github.com//rapidsai/cuxfilter/pull/237)) [@GPUtester](https://github.com/GPUtester)
+
+## 🛠️ Improvements
+
+- Update Changelog Link ([#258](https://github.com//rapidsai/cuxfilter/pull/258)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Prepare Changelog for Automation ([#253](https://github.com//rapidsai/cuxfilter/pull/253)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update 0.18 changelog entry ([#252](https://github.com//rapidsai/cuxfilter/pull/252)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Fix merge conflicts in #233 ([#234](https://github.com//rapidsai/cuxfilter/pull/234)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # cuXfilter 0.18.0 (24 Feb 2021)
 

--- a/conda/environments/cuxfilter_dev_cuda10.1.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.1.yml
@@ -17,7 +17,7 @@ dependencies:
 - datashader>=0.11.1
 - numba>=0.51.2
 - geopandas>=0.6, <=0.8.1
-- pyproj>=2.4, <=2.6.1.post1
+- pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.1.1,<=2.2.3

--- a/conda/environments/cuxfilter_dev_cuda10.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.2.yml
@@ -18,7 +18,7 @@ dependencies:
 - datashader>=0.11.1
 - numba>=0.51.2
 - geopandas>=0.6, <=0.8.1
-- pyproj>=2.4, <=2.6.1.post1
+- pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.1.1,<=2.2.3

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -17,7 +17,7 @@ dependencies:
 - datashader>=0.11.1
 - numba>=0.51.2
 - geopandas>=0.6, <=0.8.1
-- pyproj>=2.4, <=2.6.1.post1
+- pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.1.1,<=2.2.3

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - cupy  >=7.8.0,<9.0.0a0
     - panel >=0.10.3
     - bokeh >=2.1.1,<=2.2.3
-    - pyproj >=2.4, <=2.6.1.post1
+    - pyproj >=2.4, <=3.0.1
     - geopandas >=0.6, <=0.8.1
     - nodejs >=12,<15
     - libwebp


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.