### PR TITLE
ENH Remove defaults channel from conda build

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ cuxfilter conda example installation:
 .. code-block:: bash
 
     conda install -c rapidsai -c nvidia -c conda-forge \
-        -c defaults cuxfilter=0.15 python=3.7 cudatoolkit=10.0
+        cuxfilter=0.15 python=3.7 cudatoolkit=10.0
 
 Docker container
 ----------------


### PR DESCRIPTION
Remove `defaults` channel from conda build
