### PR TITLE
ENH Remove 'rapidsai-nightly' conda channel when building main branch

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,6 +43,11 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+# Remove rapidsai-nightly channel if we are building main branch
+if [ "$SOURCE_BRANCH" = "main" ]; then
+  conda config --system --remove channels rapidsai-nightly
+fi
+
 gpuci_logger "Check compiler versions"
 python --version
 $CC --version


### PR DESCRIPTION
Remove `rapidsai-nightly` conda channel when building main branch