### PR TITLE
Update `geopandas` version spec

### DIFF
--- a/conda/environments/cuxfilter_dev_cuda10.1.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.1.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=21.06
 - datashader>=0.11.1
 - numba>=0.51.2
-- geopandas>=0.6, <=0.8.1
+- geopandas >=0.9.0,<0.10.0a0
 - pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/environments/cuxfilter_dev_cuda10.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.2.yml
@@ -17,7 +17,7 @@ dependencies:
 - dask-cudf=21.06
 - datashader>=0.11.1
 - numba>=0.51.2
-- geopandas>=0.6, <=0.8.1
+- geopandas >=0.9.0,<0.10.0a0
 - pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=21.06
 - datashader>=0.11.1
 - numba>=0.51.2
-- geopandas>=0.6, <=0.8.1
+- geopandas >=0.9.0,<0.10.0a0
 - pyproj>=2.4, <=3.0.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -33,11 +33,11 @@ requirements:
     - dask-cuda {{ minor_version }}
     - datashader >=0.11.1, <0.12
     - numba >=0.51.2
-    - cupy  >=7.8.0,<10.0.0a0
+    - cupy >=7.8.0,<10.0.0a0
     - panel >=0.10.3
     - bokeh >=2.1.1,<=2.2.3
     - pyproj >=2.4, <=3.0.1
-    - geopandas >=0.6, <=0.8.1
+    - geopandas >=0.9.0,<0.10.0a0
     - nodejs >=12,<15
     - libwebp
     - pyppeteer <=0.2.2


### PR DESCRIPTION
This PR updates the `geopandas` version spec to match a recent version change in the integration repo (https://github.com/rapidsai/integration/pull/271).