### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # cuXfilter 21.06.00 (9 Jun 2021)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Update `geopandas` vesion spec ([#292](https://github.com/rapidsai/cuxfilter/pull/292)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update envionment vaiable used to detemine `cuda_vesion` ([#289](https://github.com/rapidsai/cuxfilter/pull/289)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update `CHANGELOG.md` links fo calve ([#287](https://github.com/rapidsai/cuxfilter/pull/287)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update docs build scipt ([#286](https://github.com/rapidsai/cuxfilter/pull/286)) [@ajschmidt8](https://github.com/ajschmidt8)
-- suppot space in wokspace ([#267](https://github.com/rapidsai/cuxfilter/pull/267)) [@jolounyomi](https://github.com/jolounyomi)
+- Update `geopandas` version spec ([#292](https://github.com/rapidsai/cuxfilter/pull/292)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update environment variable used to determine `cuda_version` ([#289](https://github.com/rapidsai/cuxfilter/pull/289)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links for calver ([#287](https://github.com/rapidsai/cuxfilter/pull/287)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update docs build script ([#286](https://github.com/rapidsai/cuxfilter/pull/286)) [@ajschmidt8](https://github.com/ajschmidt8)
+- support space in workspace ([#267](https://github.com/rapidsai/cuxfilter/pull/267)) [@jolorunyomi](https://github.com/jolorunyomi)
 
 # cuXfilter 0.19.0 (21 Apr 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# cuXfilter 21.06.00 (Date TBD)
+# cuXfilter 21.06.00 (9 Jun 2021)
 
-Please see https://github.com/rapidsai/cuxfilter/releases/tag/v21.06.00a for the latest changes to this development branch.
+## 🛠️ Impovements
+
+- Update `geopandas` vesion spec ([#292](https://github.com/rapidsai/cuxfilter/pull/292)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update envionment vaiable used to detemine `cuda_vesion` ([#289](https://github.com/rapidsai/cuxfilter/pull/289)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links fo calve ([#287](https://github.com/rapidsai/cuxfilter/pull/287)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update docs build scipt ([#286](https://github.com/rapidsai/cuxfilter/pull/286)) [@ajschmidt8](https://github.com/ajschmidt8)
+- suppot space in wokspace ([#267](https://github.com/rapidsai/cuxfilter/pull/267)) [@jolounyomi](https://github.com/jolounyomi)
 
 # cuXfilter 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.