### PR TITLE
Update `pyppeteer` import

### DIFF
--- a/python/cuxfilter/assets/screengrab.py
+++ b/python/cuxfilter/assets/screengrab.py
@@ -1,4 +1,7 @@
-from pyppeteer import launch
+try:
+    from pyppeteer import launch
+except ImportError:
+    pass
 
 
 async def screengrab(url):


### PR DESCRIPTION
This PR is a continuation of #307. It adds a `try`/`except` block so that `cuxfilter` can be imported without any issues if the `pyppeteer` module is missing.