### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,6 @@ jupyter labextension install @pyviz/jupyterlab_pyviz
 jupyter labextension install jupyterlab_bokeh
 ```
 
-**Pyppeteer package not found**
-
-Due to a [CVE](https://github.com/pyppeteer/pyppeteer/issues/275#issuecomment-882838194) that affects our CI containers, pyppeteer is no longer packaged in 21.06 until the issues are resolved. To use the `dashboard.preview()` feature, pyppeteer can be installed via pip (`pip install -U git+https://github.com/pyppeteer/pyppeteer@dev`).
-
 ## Download Datasets
 
 1. Auto download datasets

--- a/conda/environments/cuxfilter_dev_cuda10.1.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.1.yml
@@ -22,6 +22,7 @@ dependencies:
 - pandoc=<2.0.0
 - bokeh>=2.3.2,<2.4
 - panel>=0.10.3
+- pyppeteer>=0.2.6
 - cudatoolkit=10.1
 - nodejs
 - recommonmark

--- a/conda/environments/cuxfilter_dev_cuda10.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda10.2.yml
@@ -23,6 +23,7 @@ dependencies:
 - pandoc=<2.0.0
 - bokeh>=2.3.2,<2.4
 - panel>=0.10.3
+- pyppeteer>=0.2.6
 - cudatoolkit=10.2
 - nodejs
 - recommonmark

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -22,6 +22,7 @@ dependencies:
 - pandoc=<2.0.0
 - bokeh>=2.3.2,<2.4
 - panel>=0.10.3
+- pyppeteer>=0.2.6
 - cudatoolkit=11.0
 - nodejs
 - recommonmark

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - numba >=0.51.2
     - cupy >=7.8.0,<10.0.0a0
     - panel >=0.10.3
+    - pyppeteer>=0.2.6
     - bokeh >=2.3.2,<2.4
     - pyproj >=2.4, <=3.1
     - geopandas >=0.9.0,<0.10.0a0

--- a/python/cuxfilter/assets/screengrab.py
+++ b/python/cuxfilter/assets/screengrab.py
@@ -1,7 +1,4 @@
-try:
-    from pyppeteer import launch
-except ImportError:
-    pass
+from pyppeteer import launch
 
 
 async def screengrab(url):


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.