### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# cuXfilter 21.12.00 (Date TBD)
+# cuXfilter 21.12.00 (9 Dec 2021)
 
-Please see https://github.com/rapidsai/cuxfilter/releases/tag/v21.12.00a for the latest changes to this development branch.
+## 📖 Documentation
+
+- update docstrings examples to fix #328 ([#329](https://github.com/rapidsai/cuxfilter/pull/329)) [@AjayThorve](https://github.com/AjayThorve)
 
 # cuXfilter 21.10.00 (7 Oct 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.