### PR TITLE
Build packages using mambabuild

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# COPYRIGHT (c) 2020, NVIDIA CORPORATION.
+# COPYRIGHT (c) 2020-2022, NVIDIA CORPORATION.
 ######################################
 # cuXfilter CPU conda build script for CI #
 ######################################
@@ -61,12 +61,15 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
+# FIXME: Remove
+gpuci_mamba_retry install -c conda-forge boa
+
 ################################################################################
 # BUILD - Conda package builds
 ################################################################################
 
 echo "Building cuxfilter"
-gpuci_conda_retry build conda/recipes/cuxfilter --python=$PYTHON
+gpuci_conda_retry mambabuild conda/recipes/cuxfilter --python=$PYTHON
 
 ################################################################################
 # UPLOAD - Conda packages

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -69,10 +69,13 @@ conda list --show-channel-urls
 # BUILD - Build cuxfilter
 ################################################################################
 
+# TODO: Move boa install to gpuci/rapidsai
+gpuci_mamba_retry install boa
+
 gpuci_logger "Build and install cuxfilter"
 cd "${WORKSPACE}"
 CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
-gpuci_conda_retry build  --croot "${CONDA_BLD_DIR}" conda/recipes/cuxfilter --python=$PYTHON
+gpuci_conda_retry mambabuild  --croot "${CONDA_BLD_DIR}" conda/recipes/cuxfilter --python=$PYTHON
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" cuxfilter
 
 ################################################################################


### PR DESCRIPTION
Use `mambabuild` to build `conda` packages. This should speed up the builds and help to debug `conda` conflict issues