### PR TITLE
Use conda compilers

### DIFF
--- a/conda/recipes/cuxfilter/conda_build_config.yaml
+++ b/conda/recipes/cuxfilter/conda_build_config.yaml
@@ -1,0 +1,8 @@
+c_compiler_version:
+  - 9
+
+cxx_compiler_version:
+  - 9
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -17,12 +17,13 @@ build:
   string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+  host:
     - python
     - setuptools
   run:


### PR DESCRIPTION
This PR enables the usage of conda compilers to build conda packages. This is required to use `mambabuild`