### PR TITLE
Update `bokeh` version

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,7 +59,7 @@ gpuci_mamba_retry install -y \
                "cuspatial=$MINOR_VERSION.*" \
                "dask-cudf=$MINOR_VERSION.*" "dask-cuda=$MINOR_VERSION.*" \
                "numba>=0.54" \
-               "bokeh>=2.3.2,<=2.4" \
+               "bokeh>=2.4.2,<=2.5" \
                "rapids-build-env=$MINOR_VERSION.*" \
                "rapids-notebook-env=$MINOR_VERSION.*"
 

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0
-- bokeh>=2.3.2,<=2.4
+- bokeh>=2.4.2,<=2.5
 - panel>=0.10.3,<=0.12.4
 - pyppeteer>=0.2.6
 - cudatoolkit=11.0

--- a/conda/environments/cuxfilter_dev_cuda11.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.2.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0
-- bokeh>=2.3.2,<=2.4
+- bokeh>=2.4.2,<=2.5
 - panel>=0.10.3,<=0.12.4
 - pyppeteer>=0.2.6
 - cudatoolkit=11.2

--- a/conda/environments/cuxfilter_dev_cuda11.4.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.4.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0
-- bokeh>=2.3.2,<=2.4
+- bokeh>=2.4.2,<=2.5
 - panel>=0.10.3,<=0.12.4
 - pyppeteer>=0.2.6
 - cudatoolkit=11.4

--- a/conda/environments/cuxfilter_dev_cuda11.5.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.5.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0
-- bokeh>=2.3.2,<=2.4
+- bokeh>=2.4.2,<=2.5
 - panel>=0.10.3,<=0.12.4
 - pyppeteer>=0.2.6
 - cudatoolkit=11.5

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - cupy >=7.8.0,<10.0.0a0
     - panel >=0.10.3,<=0.12.4
     - pyppeteer>=0.2.6
-    - bokeh >=2.3.2,<=2.4
+    - bokeh>=2.4.2,<=2.5
     - pyproj >=2.4, <=3.1
     - geopandas >=0.9.0,<0.10.0a0
     - nodejs >=12,<15


### PR DESCRIPTION
This PR updates the `bokeh` version specification to be compatible with the specification that's used by `dask=2022.03.0` ([src](https://github.com/dask/dask/blob/2022.03.0/setup.py#L20)).