### PR TITLE
Update `nodejs` version specifier

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -76,7 +76,7 @@ gpuci_logger "Build and install cuxfilter"
 cd "${WORKSPACE}"
 CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 gpuci_conda_retry mambabuild  --croot "${CONDA_BLD_DIR}" conda/recipes/cuxfilter --python=$PYTHON
-gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" cuxfilter "nodejs>=14"
+gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" cuxfilter
 
 ################################################################################
 # TEST - Run pytest

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -76,7 +76,7 @@ gpuci_logger "Build and install cuxfilter"
 cd "${WORKSPACE}"
 CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 gpuci_conda_retry mambabuild  --croot "${CONDA_BLD_DIR}" conda/recipes/cuxfilter --python=$PYTHON
-gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" cuxfilter
+gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" cuxfilter "nodejs>=14"
 
 ################################################################################
 # TEST - Run pytest

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - bokeh>=2.4.2,<=2.5
     - pyproj >=2.4, <=3.1
     - geopandas >=0.9.0,<0.10.0a0
-    - nodejs >=12,<15
+    - nodejs >=14
     - libwebp
     - jupyter-server-proxy
     - pydeck >=0.3, <=0.5.0


### PR DESCRIPTION
The current `nodejs` version specifier is outdated and is causing issues related to https://github.com/rapidsai/cuxfilter/issues/384. This PR updates the specifier to uncap the maximum version and set a new minimum.