### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - bokeh>=2.4.2,<=2.5
     - pyproj >=2.4, <=3.1
     - geopandas >=0.9.0,<0.10.0a0
-    - nodejs >=12,<15
+    - nodejs >=14
     - libwebp
     - jupyter-server-proxy
     - pydeck >=0.3, <=0.5.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.