### PR TITLE
Update `geopandas` version specificer

### DIFF
--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -18,7 +18,7 @@ dependencies:
 - datashader>0.13, <0.14
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
-- geopandas >=0.9.0,<0.10.0a0
+- geopandas >=0.11.0
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/environments/cuxfilter_dev_cuda11.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.2.yml
@@ -18,7 +18,7 @@ dependencies:
 - datashader>0.13, <0.14
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
-- geopandas >=0.9.0,<0.10.0a0
+- geopandas >=0.11.0
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/environments/cuxfilter_dev_cuda11.4.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.4.yml
@@ -18,7 +18,7 @@ dependencies:
 - datashader>0.13, <0.14
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
-- geopandas >=0.9.0,<0.10.0a0
+- geopandas >=0.11.0
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/environments/cuxfilter_dev_cuda11.5.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.5.yml
@@ -18,7 +18,7 @@ dependencies:
 - datashader>0.13, <0.14
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
-- geopandas >=0.9.0,<0.10.0a0
+- geopandas >=0.11.0
 - pyproj>=2.4, <=3.1
 - libwebp
 - pandoc=<2.0.0

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - pyppeteer>=0.2.6
     - bokeh>=2.4.2,<=2.5
     - pyproj >=2.4, <=3.1
-    - geopandas >=0.9.0,<0.10.0a0
+    - geopandas >=0.11.0
     - nodejs >=14
     - libwebp
     - jupyter-server-proxy


### PR DESCRIPTION
Similarly to https://github.com/rapidsai/cuspatial/pull/585, this PR updates the `geopandas` version specifier to ensure compatibility with the rest of RAPIDS.