### PR TITLE
Update `pyproj` version specifier

### DIFF
--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -19,7 +19,7 @@ dependencies:
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
 - geopandas >=0.11.0
-- pyproj>=2.4, <=3.1
+- pyproj>=2.4,<=3.4
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5

--- a/conda/environments/cuxfilter_dev_cuda11.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.2.yml
@@ -19,7 +19,7 @@ dependencies:
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
 - geopandas >=0.11.0
-- pyproj>=2.4, <=3.1
+- pyproj>=2.4,<=3.4
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5

--- a/conda/environments/cuxfilter_dev_cuda11.4.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.4.yml
@@ -19,7 +19,7 @@ dependencies:
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
 - geopandas >=0.11.0
-- pyproj>=2.4, <=3.1
+- pyproj>=2.4,<=3.4
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5

--- a/conda/environments/cuxfilter_dev_cuda11.5.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.5.yml
@@ -19,7 +19,7 @@ dependencies:
 - holoviews>1.14.1, <=1.14.6
 - numba>=0.54
 - geopandas >=0.11.0
-- pyproj>=2.4, <=3.1
+- pyproj>=2.4,<=3.4
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - panel >=0.12.7,<0.13
     - pyppeteer>=0.2.6
     - bokeh>=2.4.2,<=2.5
-    - pyproj >=2.4, <=3.1
+    - pyproj>=2.4,<=3.4
     - geopandas >=0.11.0
     - nodejs >=14
     - libwebp


### PR DESCRIPTION
This PR updates the `pyproj` version specifier to be compatible with a newer version of `gdal` that will be used in `cuspatial`. `gdal` needs to be bumped to address a CVE.