### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-# cuXfilter 22.12.00 (Date TBD)
+# cuXfilter 22.12.00 (8 Dec 2022)
 
-Please see https://github.com/rapidsai/cuxfilter/releases/tag/v22.12.00a for the latest changes to this development branch.
+## 📖 Documentation
+
+- Create symlink to 10_minutes_to_cuxfilter.ipynb into the notebooks fo… ([#413](https://github.com/rapidsai/cuxfilter/pull/413)) [@taureandyernv](https://github.com/taureandyernv)
+
+## 🛠️ Improvements
+
+- Update `panel` version ([#421](https://github.com/rapidsai/cuxfilter/pull/421)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Remove stale labeler ([#410](https://github.com/rapidsai/cuxfilter/pull/410)) [@raydouglass](https://github.com/raydouglass)
 
 # cuXfilter 22.10.00 (12 Oct 2022)
 

--- a/conda/environments/cuxfilter_dev_cuda11.0.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.0.yml
@@ -23,7 +23,7 @@ dependencies:
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5
-- panel>=0.12.7,<0.13
+- panel>=0.14.0,<0.15
 - pyppeteer>=0.2.6
 - cudatoolkit=11.0
 - nodejs

--- a/conda/environments/cuxfilter_dev_cuda11.2.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.2.yml
@@ -23,7 +23,7 @@ dependencies:
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5
-- panel>=0.12.7,<0.13
+- panel>=0.14.0,<0.15
 - pyppeteer>=0.2.6
 - cudatoolkit=11.2
 - nodejs

--- a/conda/environments/cuxfilter_dev_cuda11.4.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.4.yml
@@ -23,7 +23,7 @@ dependencies:
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5
-- panel>=0.12.7,<0.13
+- panel>=0.14.0,<0.15
 - pyppeteer>=0.2.6
 - cudatoolkit=11.4
 - nodejs

--- a/conda/environments/cuxfilter_dev_cuda11.5.yml
+++ b/conda/environments/cuxfilter_dev_cuda11.5.yml
@@ -23,7 +23,7 @@ dependencies:
 - libwebp
 - pandoc=<2.0.0
 - bokeh>=2.4.2,<=2.5
-- panel>=0.12.7,<0.13
+- panel>=0.14.0,<0.15
 - pyppeteer>=0.2.6
 - cudatoolkit=11.5
 - nodejs

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - holoviews>1.14.1, <=1.14.6
     - numba >=0.54
     - cupy >=9.5.0,<12.0.0a0
-    - panel >=0.12.7,<0.13
+    - panel >=0.14.0,<0.15
     - pyppeteer>=0.2.6
     - bokeh>=2.4.2,<=2.5
     - pyproj>=2.4,<=3.4


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.