### PR TITLE
Build CUDA 11.8 and Python 3.10 Packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   python-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [python-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,27 +17,27 @@ jobs:
       - conda-python-tests
       - conda-notebook-tests
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@cuda-118
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@cuda-118
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: pull-request
       run_codecov: false
   conda-notebook-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@cuda-118
     with:
       build_type: pull-request
       node_type: "gpu-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ cd $CUXFILTER_HOME
 - Create the conda development environment `cuxfilter_dev`:
 ```bash
 # create the conda environment (assuming in base `cuxfilter` directory)
-conda env create --name cuxfilter_dev --file conda/environments/all_cuda-115_arch-x86_64.yaml
+conda env create --name cuxfilter_dev --file conda/environments/all_cuda-118_arch-x86_64.yaml
 # activate the environment
 source activate cuxfilter_dev
 ```
@@ -150,7 +150,7 @@ Done! You are ready to develop for the cuxfilter OSS project
 
 cuxfilter.py acts like a connector library and it is easy to add support for new libraries. The cuxfilter/charts/core directory has all the core chart classes which can be inherited and used to implement a few (viz related) functions and support dashboarding in cuxfilter directly.
 
-You can see the examples to implement viz libraries in the bokeh and datashader directories. 
+You can see the examples to implement viz libraries in the bokeh and datashader directories.
 
 Current plan is to add support for the following libraries apart from bokeh and datashader:
 1. deckgl

--- a/README.md
+++ b/README.md
@@ -159,17 +159,17 @@ cuxfilter can be installed with conda ([miniconda](https://conda.io/miniconda.ht
 For `cuxfilter version == 23.02` :
 
 ```bash
-# for CUDA 11.5
+# for CUDA 11.8
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+    cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 ```
 
 For the nightly version of `cuxfilter` :
 
 ```bash
-# for CUDA 11.5
+# for CUDA 11.8
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.9 cudatoolkit=11.5
+    cuxfilter python=3.10 cudatoolkit=11.8
 ```
 
 Note: cuxfilter is supported only on Linux, and with Python versions 3.8 and later.

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -33,7 +33,8 @@ pushd notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS=""
+# FIXME: remove graphs.ipynb notebook once cugraph segfault is fixed upstream
+SKIPNBS="graphs.ipynb"
 
 # Set SUITEERROR to failure if any run fails
 SUITEERROR=0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - dask-cudf=23.02
 - datashader>0.13,<=0.14.3
 - geopandas>=0.11.0
-- holoviews>1.14.1,<=1.14.6
+- holoviews>=1.14.8,<=1.15.3
 - ipython
 - jupyter-server-proxy
 - jupyter_sphinx
@@ -26,7 +26,7 @@ dependencies:
 - numpydoc
 - packaging
 - pandoc<=2.0.0
-- panel>=0.14.0,<0.15
+- panel >=0.14.0,<=0.14.1
 - pre-commit
 - pydeck>=0.3,<=0.5.0
 - pyppeteer>=0.2.6

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -7,12 +7,12 @@ channels:
 - nvidia
 dependencies:
 - bokeh>=2.4.2,<=2.5
-- cudatoolkit=11.5
-- cudf=23.02.*
-- cugraph=23.02.*
-- cuspatial=23.02.*
-- dask-cuda=23.02.*
-- dask-cudf=23.02.*
+- cudatoolkit=11.8
+- cudf=23.02
+- cugraph=23.02
+- cuspatial=23.02
+- dask-cuda=23.02
+- dask-cudf=23.02
 - datashader>0.13,<=0.14.3
 - geopandas>=0.11.0
 - holoviews>1.14.1,<=1.14.6
@@ -33,10 +33,10 @@ dependencies:
 - pyproj>=2.4,<=3.4
 - pytest
 - pytest-cov
-- python>=3.8,<3.10
+- python>=3.8,<3.11
 - recommonmark
 - sphinx
 - sphinx-markdown-tables
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
-name: all_cuda-115_arch-x86_64
+name: all_cuda-118_arch-x86_64

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -29,13 +29,13 @@ requirements:
     - dask-cudf ={{ minor_version }}
     - datashader >0.13,<0.14
     - geopandas >=0.11.0
-    - holoviews >1.14.1,<=1.14.6
+    - holoviews >=1.14.8,<=1.15.3
     - jupyter-server-proxy
     - libwebp
     - nodejs >=14
     - numba >=0.54
     - packaging
-    - panel >=0.14.0,<0.15
+    - panel >=0.14.0,<=0.14.1
     - pydeck >=0.3,<=0.5.0
     - pyppeteer >=0.2.6
     - pyproj >=2.4,<=3.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,12 +109,12 @@ dependencies:
           - bokeh>=2.4.2,<=2.5
           - datashader>0.13,<=0.14.3
           - geopandas>=0.11.0
-          - holoviews>1.14.1,<=1.14.6
+          - holoviews>=1.14.8,<=1.15.3
           - jupyter-server-proxy
           - libwebp
           - nodejs>=14
           - packaging
-          - panel>=0.14.0,<0.15
+          - panel >=0.14.0,<=0.14.1
           - pydeck>=0.3,<=0.5.0
           - pyppeteer>=0.2.6
           - pyproj>=2.4,<=3.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["11.5"]
+      cuda: ["11.8"]
       arch: [x86_64]
     includes:
       - cudatoolkit
@@ -51,6 +51,10 @@ dependencies:
               cuda: "11.5"
             packages:
               - cudatoolkit=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cudatoolkit=11.8
   develop:
     common:
       - output_types: [conda, requirements]
@@ -78,7 +82,7 @@ dependencies:
           - notebook>=0.5.0
       - output_types: [conda]
         packages:
-          - cugraph=23.02.*
+          - cugraph=23.02
   py_version:
     specific:
       - output_types: conda
@@ -92,8 +96,12 @@ dependencies:
             packages:
               - python=3.9
           - matrix:
+              py: "3.10"
             packages:
-              - python>=3.8,<3.10
+              - python=3.10
+          - matrix:
+            packages:
+              - python>=3.8,<3.11
   run:
     common:
       - output_types: [conda, requirements]
@@ -112,10 +120,10 @@ dependencies:
           - pyproj>=2.4,<=3.4
       - output_types: conda
         packages:
-          - cudf=23.02.*
-          - cuspatial=23.02.*
-          - dask-cuda=23.02.*
-          - dask-cudf=23.02.*
+          - cudf=23.02
+          - cuspatial=23.02
+          - dask-cuda=23.02
+          - dask-cudf=23.02
   test_python:
     common:
       - output_types: [conda, requirements]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ cuxfilter conda example installation:
 .. code-block:: bash
 
     conda install -c rapidsai -c conda-forge -c nvidia \
-        cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+        cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 
 Docker container
 ----------------
@@ -20,10 +20,10 @@ cuxfilter docker example installation:
 
 .. code-block:: bash
 
-    # ex. for CUDA 11.5
-    docker pull rapidsai/rapidsai:cuda11.5-runtime-ubuntu20.04
+    # ex. for CUDA 11.8
+    docker pull rapidsai/rapidsai:cuda11.8-runtime-ubuntu20.04
     docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-        rapidsai/rapidsai:cuda11.5-runtime-ubuntu20.04
+        rapidsai/rapidsai:cuda11.8-runtime-ubuntu20.04
 
     # open http://localhost:8888
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -39,11 +39,11 @@ conda install ipykernel
 
 # for stable rapids version
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+    cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 
 # for nightly rapids version
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.9 cudatoolkit=11.5
+    cuxfilter python=3.10 cudatoolkit=11.8
 ```
 
 > Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,9 +4,6 @@ import versioneer
 with open("README.md") as f:
     readme = f.read()
 
-# with open('LICENSE') as f:
-#     license = f.read()
-
 setup(
     name="cuxfilter",
     version=versioneer.get_version(),
@@ -20,8 +17,9 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     packages=find_packages(
         include=["cuxfilter", "cuxfilter.*"],


### PR DESCRIPTION
## Description

This PR updates `cuxfilter` to build against branch [cuda-118](https://github.com/rapidsai/shared-action-workflows/compare/cuda-118) of the `shared-action-workflow` repository.

That branch contains updates for CUDA 11.8 and Python 3.10 packages.

It also includes some minor file renames.

Depends on
- https://github.com/rapidsai/cudf/pull/12457
- https://github.com/rapidsai/cuspatial/pull/865
