### PR TITLE
Build CUDA `11.8` and Python `3.10` Packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   python-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [python-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,27 +17,27 @@ jobs:
       - conda-python-tests
       - conda-notebook-tests
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@cuda-118
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@cuda-118
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: pull-request
       run_codecov: false
   conda-notebook-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@cuda-118
     with:
       build_type: pull-request
       node_type: "gpu-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ cd $CUXFILTER_HOME
 - Create the conda development environment `cuxfilter_dev`:
 ```bash
 # create the conda environment (assuming in base `cuxfilter` directory)
-conda env create --name cuxfilter_dev --file conda/environments/all_cuda-115_arch-x86_64.yaml
+conda env create --name cuxfilter_dev --file conda/environments/all_cuda-118_arch-x86_64.yaml
 # activate the environment
 source activate cuxfilter_dev
 ```

--- a/README.md
+++ b/README.md
@@ -159,17 +159,17 @@ cuxfilter can be installed with conda ([miniconda](https://conda.io/miniconda.ht
 For `cuxfilter version == 23.02` :
 
 ```bash
-# for CUDA 11.5
+# for CUDA 11.8
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+    cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 ```
 
 For the nightly version of `cuxfilter` :
 
 ```bash
-# for CUDA 11.5
+# for CUDA 11.8
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.9 cudatoolkit=11.5
+    cuxfilter python=3.10 cudatoolkit=11.8
 ```
 
 Note: cuxfilter is supported only on Linux, and with Python versions 3.8 and later.

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 - nvidia
 dependencies:
 - bokeh>=2.4.2,<=2.5
-- cudatoolkit=11.5
+- cudatoolkit=11.8
 - cudf=23.02.*
 - cugraph=23.02.*
 - cuspatial=23.02.*
@@ -33,10 +33,10 @@ dependencies:
 - pyproj>=2.4,<=3.4
 - pytest
 - pytest-cov
-- python>=3.8,<3.10
+- python>=3.8,<3.11
 - recommonmark
 - sphinx
 - sphinx-markdown-tables
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
-name: all_cuda-115_arch-x86_64
+name: all_cuda-118_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["11.5"]
+      cuda: ["11.8"]
       arch: [x86_64]
     includes:
       - cudatoolkit
@@ -51,6 +51,10 @@ dependencies:
               cuda: "11.5"
             packages:
               - cudatoolkit=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cudatoolkit=11.8
   develop:
     common:
       - output_types: [conda, requirements]
@@ -92,8 +96,12 @@ dependencies:
             packages:
               - python=3.9
           - matrix:
+              py: "3.10"
             packages:
-              - python>=3.8,<3.10
+              - python=3.10
+          - matrix:
+            packages:
+              - python>=3.8,<3.11
   run:
     common:
       - output_types: [conda, requirements]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ cuxfilter conda example installation:
 .. code-block:: bash
 
     conda install -c rapidsai -c conda-forge -c nvidia \
-        cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+        cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 
 Docker container
 ----------------
@@ -20,10 +20,10 @@ cuxfilter docker example installation:
 
 .. code-block:: bash
 
-    # ex. for CUDA 11.5
-    docker pull rapidsai/rapidsai:cuda11.5-runtime-ubuntu20.04
+    # ex. for CUDA 11.8
+    docker pull rapidsai/rapidsai:cuda11.8-runtime-ubuntu20.04
     docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-        rapidsai/rapidsai:cuda11.5-runtime-ubuntu20.04
+        rapidsai/rapidsai:cuda11.8-runtime-ubuntu20.04
 
     # open http://localhost:8888
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -39,11 +39,11 @@ conda install ipykernel
 
 # for stable rapids version
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.9 cudatoolkit=11.5
+    cuxfilter=23.02 python=3.10 cudatoolkit=11.8
 
 # for nightly rapids version
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.9 cudatoolkit=11.5
+    cuxfilter python=3.10 cudatoolkit=11.8
 ```
 
 > Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,8 +20,9 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     packages=find_packages(
         include=["cuxfilter", "cuxfilter.*"],


### PR DESCRIPTION
This PR updates `cuxfilter` to build against branch [cuda-118](https://github.com/rapidsai/shared-action-workflows/compare/cuda-118) of the `shared-action-workflow` repository.

That branch contains updates for CUDA `11.8` and Python `3.10` packages.

It also includes some minor file renames.
