### PR TITLE
Re-enable `graphs.ipynb` notebook in CI

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -33,8 +33,7 @@ pushd notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-# FIXME: remove graphs.ipynb notebook once cugraph segfault is fixed upstream
-SKIPNBS="graphs.ipynb"
+SKIPNBS=""
 
 # Set SUITEERROR to failure if any run fails
 SUITEERROR=0


### PR DESCRIPTION
The `graphs.ipynb` notebook was disabled in #426 due to some upstream issues with `cugraph`.

This PR reverts that change to re-enable the notebook.
