### PR TITLE
Fix broken symlink

### DIFF
--- a/notebooks/10_minutes_to_cuxfilter.ipynb
+++ b/notebooks/10_minutes_to_cuxfilter.ipynb
@@ -1,1 +1,1 @@
-../docs/source/10_minutes_to_cuxfilter.ipynb
+../docs/source/user_guide/10_minutes_to_cuxfilter.ipynb


### PR DESCRIPTION
Follow up from #500 where a notebook was moved but the symlink in `notebooks` was not updated.

Related: #419