### PR TITLE
Fix nightly wheel testing workflow.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,10 +23,12 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   wheel-tests:
-    needs: wheel-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-pure-test.yml@branch-23.08
     with:
-      build_type: pull-request
+      build_type: nightly
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
       package-name: cuxfilter
       test-unittest: "python -m pytest -n 8 ./python/cuxfilter/tests"


### PR DESCRIPTION
This PR fixes the nightly wheel testing workflow. It looks like this was copied straight from `pr.yaml` rather than adapted for nightly testing.

```
Invalid workflow file: .github/workflows/test.yaml#L26
The workflow is not valid. .github/workflows/test.yaml (Line: 26, Col: 12): Job 'wheel-tests' depends on unknown job 'wheel-build'.
```

https://github.com/rapidsai/cuxfilter/actions/runs/5653917680