### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,7 +64,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
   wheel-tests:
     needs: wheel-build
     secrets: inherit
@@ -72,4 +72,4 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,4 +31,4 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel.sh
-      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.10" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
+      matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ For nightly version `cuxfilter version == 24.04` :
 ```bash
 # for CUDA 12.0
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=24.04 python=3.10 cuda-version=12.0
+    cuxfilter=24.04 python=3.11 cuda-version=12.0
 
 # for CUDA 11.8
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=24.04 python=3.10 cuda-version=11.8
+    cuxfilter=24.04 python=3.11 cuda-version=11.8
 ```
 
 For the stable version of `cuxfilter` :
@@ -170,11 +170,11 @@ For the stable version of `cuxfilter` :
 ```bash
 # for CUDA 12.0
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.10 cuda-version=12.0
+    cuxfilter python=3.11 cuda-version=12.0
 
 # for CUDA 11.8
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.10 cuda-version=11.8
+    cuxfilter python=3.11 cuda-version=11.8
 ```
 
 Note: cuxfilter is supported only on Linux, and with Python versions 3.8 and later.

--- a/ci/utils/external_dependencies.yaml
+++ b/ci/utils/external_dependencies.yaml
@@ -8,7 +8,7 @@ dependencies:
   - dask-cudf==24.4.*
   - cuxfilter==24.4.*
   - cuda-version=12.0
-  - python>=3.9,<3.11
+  - python>=3.9,<3.12
   - xarray-spatial
   - pycaret
   - graphistry

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -38,7 +38,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - recommonmark
 - sphinx-markdown-tables
 - sphinx>=7.2.5

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - recommonmark
 - sphinx-markdown-tables
 - sphinx>=7.2.5

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -156,8 +156,12 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
             packages:
-              - python>=3.9,<3.11
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.9,<3.12
   run:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -39,11 +39,11 @@ conda install ipykernel
 
 # for stable rapids version
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.10 cudatoolkit=11.8
+    cuxfilter=23.02 python=3.11 cudatoolkit=11.8
 
 # for nightly rapids version
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.10 cudatoolkit=11.8
+    cuxfilter python=3.11 cudatoolkit=11.8
 ```
 
 > Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
