### PR TITLE
Switch `pytest-xdist` algorithm to `worksteal`

### DIFF
--- a/ci/test_external.sh
+++ b/ci/test_external.sh
@@ -80,8 +80,10 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "running all gathered tests"
-DATASHADER_TEST_GPU=1 pytest --numprocesses=8 $FILES
- --dist=worksteal \
+DATASHADER_TEST_GPU=1 pytest \
+  --numprocesses=8 \
+  --dist=worksteal \
+  $FILES
 
 if [[ "$PROJECT" = "all" ]] || [[ "$PROJECT" = "datashader" ]]; then
     # run test_quadmesh.py separately as dask.array tests fail with numprocesses

--- a/ci/test_external.sh
+++ b/ci/test_external.sh
@@ -81,6 +81,7 @@ set +e
 
 rapids-logger "running all gathered tests"
 DATASHADER_TEST_GPU=1 pytest --numprocesses=8 $FILES
+ --dist=worksteal \
 
 if [[ "$PROJECT" = "all" ]] || [[ "$PROJECT" = "datashader" ]]; then
     # run test_quadmesh.py separately as dask.array tests fail with numprocesses

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -44,6 +44,7 @@ pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuxfilter.xml" \
    --numprocesses=8 \
+   --dist=worksteal \
   --cov-config=.coveragerc \
   --cov=cuxfilter \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuxfilter-coverage.xml" \


### PR DESCRIPTION
This PR uses the `worksteal` algorithm to accelerate parallel pytests. See https://github.com/rapidsai/cudf/pull/15207.
