### PR TITLE
Treat cuxfilter CI artifacts as pure wheels

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -47,4 +47,4 @@ cd "${package_dir}"
 
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 dist
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,7 +4,7 @@
 set -eou pipefail
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="cuxfilter_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="cuxfilter_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 ./dist
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/cuxfilter*.whl)[test]


### PR DESCRIPTION
## Description
This marks `cuxfilter` as a pure wheel, meaning that the CI artifacts are not specific to a Python version or CPU architecture. This change depends on https://github.com/rapidsai/gha-tools/pull/96, and makes CI workflows more robust by allowing the test matrix to be separated from the build matrix.
