### PR TITLE
Include CUDA 11 in build matrix for wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
       build_type: pull-request
       script: ci/build_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-tests:
     needs: wheel-build
     secrets: inherit


### PR DESCRIPTION
Updates the matrix filtering to also include CUDA 11 for wheel builds.

This switches the build matrix from `{"include":[{"ARCH":"amd64","PY_VER":"3.11","CUDA_VER":"12.2.2","LINUX_VER":"rockylinux8"}]}` to `{"include":[{"ARCH":"amd64","PY_VER":"3.11","CUDA_VER":"11.8.0","LINUX_VER":"rockylinux8"},{"ARCH":"amd64","PY_VER":"3.11","CUDA_VER":"12.2.2","LINUX_VER":"rockylinux8"}]}`
