### PR TITLE
[WIP] Avoid importing from `dask_cudf.core`

### DIFF
--- a/python/cuxfilter/assets/numba_kernels/gpu_histogram.py
+++ b/python/cuxfilter/assets/numba_kernels/gpu_histogram.py
@@ -20,7 +20,7 @@ def calc_value_counts(a_gpu, stride, min_value, custom_binning=False):
     """
     custom_binning = custom_binning and stride
 
-    if isinstance(a_gpu, dask_cudf.core.Series):
+    if isinstance(a_gpu, dask_cudf.Series):
         if not custom_binning:
             val_count = a_gpu.value_counts()
         else:
@@ -64,7 +64,7 @@ def calc_groupby(chart: Type[BaseChart], data, agg=None):
 
     if agg is None:
         temp_df[chart.y] = data.dropna(subset=[chart.x])[chart.y]
-        if isinstance(temp_df, dask_cudf.core.DataFrame):
+        if isinstance(temp_df, dask_cudf.DataFrame):
             groupby_res = getattr(
                 temp_df.groupby(by=[chart.x], sort=True), chart.aggregate_fn
             )()

--- a/python/cuxfilter/charts/core/core_view_dataframe.py
+++ b/python/cuxfilter/charts/core/core_view_dataframe.py
@@ -51,7 +51,7 @@ class ViewDataFrame:
 
     def initiate_chart(self, dashboard_cls):
         data = dashboard_cls._cuxfilter_df.data
-        if isinstance(data, dask_cudf.core.DataFrame):
+        if isinstance(data, dask_cudf.DataFrame):
             if self.force_computation:
                 self.generate_chart(data.compute())
             else:
@@ -113,7 +113,7 @@ class ViewDataFrame:
         return pn.panel(self.chart, sizing_mode="stretch_both")
 
     def reload_chart(self, data):
-        if isinstance(data, dask_cudf.core.DataFrame):
+        if isinstance(data, dask_cudf.DataFrame):
             if self.force_computation:
                 self.chart.data = self._format_data(
                     data[self.columns].compute()

--- a/python/cuxfilter/charts/core/non_aggregate/core_graph.py
+++ b/python/cuxfilter/charts/core/non_aggregate/core_graph.py
@@ -211,9 +211,7 @@ class BaseGraph(BaseChart):
                 dashboard_cls._cuxfilter_df.data[self.node_y].min(),
                 dashboard_cls._cuxfilter_df.data[self.node_y].max(),
             )
-        if isinstance(
-            dashboard_cls._cuxfilter_df.data, dask_cudf.core.DataFrame
-        ):
+        if isinstance(dashboard_cls._cuxfilter_df.data, dask_cudf.DataFrame):
             self.x_range = dd.compute(*self.x_range)
             self.y_range = dd.compute(*self.y_range)
 

--- a/python/cuxfilter/charts/datashader/plots.py
+++ b/python/cuxfilter/charts/datashader/plots.py
@@ -324,7 +324,7 @@ class Line(BaseLine):
         self.x_range = (self.source[self.x].min(), self.source[self.x].max())
         self.y_range = (self.source[self.y].min(), self.source[self.y].max())
 
-        if isinstance(data, dask_cudf.core.DataFrame):
+        if isinstance(data, dask_cudf.DataFrame):
             self.x_range = dd.compute(*self.x_range)
             self.y_range = dd.compute(*self.y_range)
 
@@ -449,7 +449,7 @@ class StackedLines(BaseStackedLine):
                 self.source[self.y].min().min(),
                 self.source[self.y].max().max(),
             )
-        if isinstance(data, dask_cudf.core.DataFrame):
+        if isinstance(data, dask_cudf.DataFrame):
             self.x_range = dd.compute(*self.x_range)
             self.y_range = dd.compute(*self.y_range)
 

--- a/python/cuxfilter/charts/panel_widgets/plots.py
+++ b/python/cuxfilter/charts/panel_widgets/plots.py
@@ -114,7 +114,7 @@ class DateRangeSlider(BaseWidget):
             _series = dashboard_cls._cuxfilter_df.data[self.x].value_counts()
             self.data_points = (
                 _series.compute().shape[0]
-                if isinstance(_series, dask_cudf.core.Series)
+                if isinstance(_series, dask_cudf.Series)
                 else _series.shape[0]
             )
             del _series
@@ -343,7 +343,7 @@ class MultiChoice(BaseWidget):
         """
         if self.label_map is None:
             self.list_of_values = data[self.x].unique()
-            if isinstance(data, dask_cudf.core.DataFrame):
+            if isinstance(data, dask_cudf.DataFrame):
                 self.list_of_values = self.list_of_values.compute()
 
             self.list_of_values = self.list_of_values.to_pandas().tolist()


### PR DESCRIPTION
This PR is intended to resolve test failures related to the recent dask-expr migration in `dask.dataframe`. I noticed that cuxfilter was importing from `dask_cudf.core` (no longer allowed when query-planning is enabled). There may be other issues as well.