### PR TITLE
Fix libwebp dependency

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -22,7 +22,7 @@ dependencies:
 - ipython
 - jupyter-server-proxy
 - jupyter_sphinx
-- libwebp
+- libwebp-base
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - ipython
 - jupyter-server-proxy
 - jupyter_sphinx
-- libwebp
+- libwebp-base
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - geopandas >=0.11.0
     - holoviews>=1.16
     - jupyter-server-proxy
-    - libwebp
+    - libwebp-base
     - nodejs >=14
     - numba >=0.57
     - numpy >=1.23,<2.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -182,7 +182,7 @@ dependencies:
         packages:
           - cupy>=12.0.0
           - nodejs>=18
-          - libwebp
+          - libwebp-base
       - output_types: [requirements, pyproject]
         packages:
           - cupy-cuda11x>=12.0.0


### PR DESCRIPTION
Replace libwebp with libwebp-base to resolve dependency conflict with the [cucim](https://github.com/rapidsai/cucim) package.
