### PR TITLE
remove .gitattributes

### DIFF
--- a/python/.gitattributes
+++ b/python/.gitattributes
@@ -1,1 +1,0 @@
-cuxfilter/_version.py export-subst


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31

Removes `.gitattributes` files.

These were added in #66 for use with `versioneer`. Per the `git` docs ([link](https://git-scm.com/docs/gitattributes#_export_subst)), setting the attribute `export-subst` on a file via a `.gitattributes` tell `git` to replace placeholders in the file with some `git` information.

This is no longer done in `_version.py` files in this project, and this project no longer uses `versioneer` (#497). `rapids-build-backend` handles storing git commit information in the published packages.

## Notes for Reviewers

For more details, see https://github.com/rapidsai/build-planning/issues/31#issuecomment-2176853319