### PR TITLE
Merge branch-24.06 into branch-24.08

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
       build_type: pull-request
       script: ci/build_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# cuxfilter 24.06.00 (5 Jun 2024)
+
+## 🐛 Bug Fixes
+
+- Avoid importing from `dask_cudf.core` ([#593](https://github.com/rapidsai/cuxfilter/pull/593)) [@rjzamora](https://github.com/rjzamora)
+
+## 🛠️ Improvements
+
+- Enable FutureWarnings/DeprecationWarnings as errors ([#595](https://github.com/rapidsai/cuxfilter/pull/595)) [@mroeschke](https://github.com/mroeschke)
+- Fix libwebp dependency ([#594](https://github.com/rapidsai/cuxfilter/pull/594)) [@AjayThorve](https://github.com/AjayThorve)
+- Prevent path conflict in builds ([#583](https://github.com/rapidsai/cuxfilter/pull/583)) [@AyodeAwe](https://github.com/AyodeAwe)
+
 # cuXfilter 24.04.00 (10 Apr 2024)
 
 ## 🐛 Bug Fixes


### PR DESCRIPTION
Replaces #598.

That PR not being merged means the changes from https://github.com/rapidsai/cuxfilter/pull/589 did not make it onto 24.08, which is why there are no CUDA 11 nightly wheels at https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/cuxfilter-cu11/.

This fixes that. I created this branch manually, following the approach at https://docs.rapids.ai/maintainers/forward-merge.

**this should be non-squash admin merged**, like other forward-merger PRs.