### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ conda install -c rapidsai -c conda-forge -c nvidia \
     cuxfilter python=3.11 cuda-version=11.8
 ```
 
-Note: cuxfilter is supported only on Linux, and with Python versions 3.8 and later.
+Note: cuxfilter is supported only on Linux, and with Python versions 3.10 and 3.11.
 
 ### PyPI
 

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -38,7 +38,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - recommonmark
 - setuptools

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - recommonmark
 - setuptools

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -164,10 +164,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.9"
-            packages:
-              - python=3.9
-          - matrix:
               py: "3.10"
             packages:
               - python=3.10
@@ -177,7 +173,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.9,<3.12
+              - python>=3.10,<3.12
   rapids_build_setuptools:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -271,6 +267,6 @@ dependencies:
           - *cuspatial_unsuffixed
           - *dask_cudf_unsuffixed
           - cuxfilter==24.10.*,>=0.0.0a0
-          - python>=3.9,<3.12
+          - python>=3.10,<3.12
           - pytest-benchmark
           - pytest-xdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ["py39"]
+target-version = ["py310"]
 include = '\.py?$'
 force-exclude = '''
 /(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     {name = "NVIDIA Corporation"},
 ]
 license = { text = "Apache 2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "bokeh>=3.1",
     "cudf==24.10.*,>=0.0.0a0",
@@ -38,7 +38,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/88

Finishes the work of dropping Python 3.9 support.

This project stopped building / testing against Python 3.9 as of https://github.com/rapidsai/shared-workflows/pull/235.
This PR updates configuration and docs to reflect that.

## Notes for Reviewers

### How I tested this

Checked that there were no remaining uses like this:

```shell
git grep -E '3\.9'
git grep '39'
git grep 'py39'
```

And similar for variations on Python 3.8 (to catch things that were missed the last time this was done).
