### PR TITLE
Add support for Python 3.12, drop pyppeteer dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   python-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [python-build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
     if: github.ref_type == 'branch'
     needs: python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@python-3.12
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}
@@ -59,7 +59,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -71,7 +71,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,27 +20,27 @@ jobs:
       - wheel-build
       - wheel-tests
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@python-3.12
   checks:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@python-3.12
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.12
     with:
       build_type: pull-request
       run_codecov: false
   conda-notebook-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@python-3.12
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -50,7 +50,7 @@ jobs:
   docs-build:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@python-3.12
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -60,7 +60,7 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.12
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
@@ -69,7 +69,7 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.12
     with:
       build_type: pull-request
       script: ci/test_wheel.sh

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   test-external:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@python-3.12
     with:
       build_type: branch
       node_type: "gpu-v100-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.12
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}
@@ -24,7 +24,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.12
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ For nightly version `cuxfilter version == 24.10` :
 ```bash
 # for CUDA 12.0
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=24.10 python=3.11 cuda-version=12.0
+    cuxfilter=24.10 python=3.12 cuda-version=12.0
 
 # for CUDA 11.8
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=24.10 python=3.11 cuda-version=11.8
+    cuxfilter=24.10 python=3.12 cuda-version=11.8
 ```
 
 For the stable version of `cuxfilter` :
@@ -170,14 +170,14 @@ For the stable version of `cuxfilter` :
 ```bash
 # for CUDA 12.0
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.11 cuda-version=12.0
+    cuxfilter python=3.12 cuda-version=12.0
 
 # for CUDA 11.8
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.11 cuda-version=11.8
+    cuxfilter python=3.12 cuda-version=11.8
 ```
 
-Note: cuxfilter is supported only on Linux, and with Python versions 3.10 and 3.11.
+Note: cuxfilter is supported only on Linux, and with Python versions 3.10, 3.11, and 3.12.
 
 ### PyPI
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Please see the [Demo Docker Repository](https://hub.docker.com/r/rapidsai/rapids
 ### CUDA/GPU requirements
 
 - CUDA 11.2+
-- NVIDIA driver 450.80.02+
 - Pascal architecture or better (Compute Capability >=6.0)
 
 ### Conda
@@ -155,9 +154,9 @@ cuxfilter can be installed with conda ([miniconda](https://conda.io/miniconda.ht
 For nightly version `cuxfilter version == 24.10` :
 
 ```bash
-# for CUDA 12.0
+# for CUDA 12.5
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=24.10 python=3.12 cuda-version=12.0
+    cuxfilter=24.10 python=3.12 cuda-version=12.5
 
 # for CUDA 11.8
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
@@ -177,6 +176,8 @@ conda install -c rapidsai -c conda-forge -c nvidia \
 ```
 
 Note: cuxfilter is supported only on Linux, and with Python versions 3.10, 3.11, and 3.12.
+
+> Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.
 
 ### PyPI
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Please see the [Demo Docker Repository](https://hub.docker.com/r/rapidsai/rapids
 ### CUDA/GPU requirements
 
 - CUDA 11.2+
-- Pascal architecture or better (Compute Capability >=6.0)
+- Volta architecture or newer (Compute Capability >=7.0)
 
 ### Conda
 
@@ -166,9 +166,9 @@ conda install -c rapidsai-nightly -c conda-forge -c nvidia \
 For the stable version of `cuxfilter` :
 
 ```bash
-# for CUDA 12.0
+# for CUDA 12.5
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.12 cuda-version=12.0
+    cuxfilter python=3.12 cuda-version=12.5
 
 # for CUDA 11.8
 conda install -c rapidsai -c conda-forge -c nvidia \

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Troubleshooting help can be found [on our troubleshooting page](https://docs.rap
 - bokeh
 - pyproj
 - geopandas
-- pyppeteer
 - jupyter-server-proxy
 
 ## Quick Start

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -38,7 +38,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.10,<3.12
+- python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - recommonmark
 - setuptools

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-xdist
-- python>=3.10,<3.12
+- python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - recommonmark
 - setuptools

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - numpy >=1.23,<2.0a0
     - packaging
     - panel >=1.0
-    - pyppeteer >=0.2.6
     - python
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -172,8 +172,12 @@ dependencies:
             packages:
               - python=3.11
           - matrix:
+              py: "3.12"
             packages:
-              - python>=3.10,<3.12
+              - python=3.12
+          - matrix:
+            packages:
+              - python>=3.10,<3.13
   rapids_build_setuptools:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -267,6 +271,6 @@ dependencies:
           - *cuspatial_unsuffixed
           - *dask_cudf_unsuffixed
           - cuxfilter==24.10.*,>=0.0.0a0
-          - python>=3.10,<3.12
+          - python>=3.10,<3.13
           - pytest-benchmark
           - pytest-xdist

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -32,21 +32,14 @@ These are example notebooks to showcase cuxfilter with [cuDF](https://github.com
 
 Once you have registered with your email address, simply sign in to your account, start a CPU or GPU runtime, and open your project - all in your browser.
 
-To setup a rapids environment in studio lab(you only need to do this the first time, since studio lab has 15GB of persistent storage across sessions), open a new terminal:
+To setup a RAPIDS environment in studio lab (you only need to do this the first time, since studio lab has 15GB of persistent storage across sessions),
+open a new terminal and run the following
 
 ```bash
 conda install ipykernel
-
-# for stable rapids version
-conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.12 cudatoolkit=11.8
-
-# for nightly rapids version
-conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.12 cudatoolkit=11.8
 ```
 
-> Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.
+Then install `cuxfilter` and its dependencies by following the instructions in ["Installation"](../README.md#installation) in the project's main README.
 
 Once installed, you should see a card in the launcher for that environment and kernel after about a minute.
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -39,11 +39,11 @@ conda install ipykernel
 
 # for stable rapids version
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.11 cudatoolkit=11.8
+    cuxfilter=23.02 python=3.12 cudatoolkit=11.8
 
 # for nightly rapids version
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \
-    cuxfilter python=3.11 cudatoolkit=11.8
+    cuxfilter python=3.12 cudatoolkit=11.8
 ```
 
 > Above are sample install snippets for cuxfilter, see the [Get RAPIDS version picker](https://rapids.ai/start.html) for installing the latest `cuxfilter` version.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -39,7 +39,7 @@ conda install ipykernel
 
 # for stable rapids version
 conda install -c rapidsai -c numba -c conda-forge -c nvidia \
-    cuxfilter=23.02 python=3.12 cudatoolkit=11.8
+    cuxfilter python=3.12 cudatoolkit=11.8
 
 # for nightly rapids version
 conda install -c rapidsai-nightly -c numba -c conda-forge -c nvidia \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/40

This PR adds support for Python 3.12.

## Notes for Reviewers

This is part of ongoing work to add Python 3.12 support across RAPIDS.
It temporarily introduces a build/test matrix including Python 3.12, from https://github.com/rapidsai/shared-workflows/pull/213.

A follow-up PR will revert back to pointing at the `branch-24.10` branch of `shared-workflows` once all
RAPIDS repos have added Python 3.12 support.

Additional changes needed to add this support:

* dropping dependency on `pyppeteer` (https://github.com/rapidsai/cuxfilter/pull/625/files#r1750741079)

### This will fail until all dependencies have been updates to Python 3.12

CI here is expected to fail until all of this project's upstream dependencies support Python 3.12.

This can be merged whenever all CI jobs are passing.
