### PR TITLE
Switch `traceback` to `native` in `pytest`

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -43,8 +43,8 @@ pushd python/
 pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuxfilter.xml" \
-   --numprocesses=8 \
-   --dist=worksteal \
+  --numprocesses=8 \
+  --dist=worksteal \
   --cov-config=.coveragerc \
   --cov=cuxfilter \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuxfilter-coverage.xml" \

--- a/python/cuxfilter/tests/pytest.ini
+++ b/python/cuxfilter/tests/pytest.ini
@@ -1,0 +1,4 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+[pytest]
+addopts = --tb=native


### PR DESCRIPTION
## Description
In cudf & cuml we have observed a ~10% to ~20% respectively speed up of pytest suite execution by switching pytest traceback to `--native`:

```
currently:

102474 passed, 2117 skipped, 902 xfailed in 892.16s (0:14:52)

--tb=short:

102474 passed, 2117 skipped, 902 xfailed in 898.99s (0:14:58)

--tb=no:

102474 passed, 2117 skipped, 902 xfailed in 815.98s (0:13:35)

--tb=native:

102474 passed, 2117 skipped, 902 xfailed in 820.92s (0:13:40)
```

This PR makes a similar change to `cuxfilter` repo.

xref: https://github.com/rapidsai/cudf/pull/16851

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
