### PR TITLE
remove unnecessary sccache configuration, reduce verbosity of wheel-building scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         hooks:
             - id: verify-alpha-spec
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.13.11
+        rev: v1.16.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 rapids-configure-conda-channels
 
-source rapids-configure-sccache
-
 source rapids-date-string
 
 rapids-print-env

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 package_name="cuxfilter"
 package_dir="python"
 
-source rapids-configure-sccache
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
@@ -15,6 +14,6 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 cd "${package_dir}"
 
-python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
+python -m pip wheel . -w dist -v --no-deps --disable-pip-version-check
 
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 dist


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/108

Proposes removing `sccache` configuraiton in CI scripts ... this is a pure Python project, so it doesn't need that.

It also proposes updating the `rapids-dependency-file-generator` pre-commit hook to it's latest version (something I'm trying to roll out across RAPIDS as part of https://github.com/rapidsai/build-planning/issues/108), and reducing the verbosity of wheel-building scripts.