### PR TITLE
Add upper bound to prevent usage of numba 0.61.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -27,7 +27,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/recipes/cuxfilter/meta.yaml
+++ b/conda/recipes/cuxfilter/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - jupyter-server-proxy
     - libwebp-base
     - nodejs >=14
-    - numba >=0.57
+    - numba >=0.59.1,<0.61.0a0
     - numpy >=1.23,<3.0a0
     - packaging
     - panel >=1.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -195,7 +195,7 @@ dependencies:
           - geopandas>=0.11.0
           - holoviews>=1.16.0
           - jupyter-server-proxy
-          - numba>=0.57
+          - numba>=0.59.1,<0.61.0a0
           - numpy>=1.23,<3.0a0
           - packaging
           - panel>=1.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "geopandas>=0.11.0",
     "holoviews>=1.16.0",
     "jupyter-server-proxy",
-    "numba>=0.57",
+    "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "packaging",
     "panel>=1.0",


### PR DESCRIPTION
Numba 0.61.0 just got released with couple of breaking changes, this pr is required to unblock the ci.

xref: https://github.com/rapidsai/cudf/pull/17777