### PR TITLE
require sphinx<8.2.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - recommonmark
 - setuptools
 - sphinx-markdown-tables
-- sphinx>=7.2.5
+- sphinx>=7.2.5,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - recommonmark
 - setuptools
 - sphinx-markdown-tables
-- sphinx>=7.2.5,<8.2.0
+- sphinx>=8.0.0,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - recommonmark
 - setuptools
 - sphinx-markdown-tables
-- sphinx>=7.2.5
+- sphinx>=7.2.5,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
 name: all_cuda-128_arch-x86_64

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - recommonmark
 - setuptools
 - sphinx-markdown-tables
-- sphinx>=7.2.5,<8.2.0
+- sphinx>=8.0.0,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
 name: all_cuda-128_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -159,7 +159,7 @@ dependencies:
           - pydata-sphinx-theme
           - recommonmark
           # the ceiling on sphinx can be removed when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
-          - sphinx>=7.2.5,<8.2.0
+          - sphinx>=8.0.0,<8.2.0
           - sphinx_rtd_theme
           - sphinx-markdown-tables
           - sphinxcontrib-websupport

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -158,7 +158,8 @@ dependencies:
           - pandoc<=2.0.0 # We should check and fix all "<=" pinnings
           - pydata-sphinx-theme
           - recommonmark
-          - sphinx>=7.2.5
+          # the ceiling on sphinx can be removed when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
+          - sphinx>=7.2.5,<8.2.0
           - sphinx_rtd_theme
           - sphinx-markdown-tables
           - sphinxcontrib-websupport


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/155

Fixes docs builds by temporarily putting a ceiling on `sphinx`.