### PR TITLE
Use conda-build instead of conda-mambabuild

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,7 +16,7 @@ rapids-logger "Begin py build"
 conda config --set path_conflict prevent
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
   --no-test \
   conda/recipes/cuxfilter
 


### PR DESCRIPTION
This changes from `conda mambabuild` to `conda build`. Conda now uses the mamba solver so no performance regressions are expected.

This is a temporary change as we plan to migrate to `rattler-build` in the near future. However, this is needed sooner to drop `boa` and unblock Python 3.13 migrations.

xref: https://github.com/rapidsai/build-planning/issues/149
