### PR TITLE
Quote head_rev in conda recipes

### DIFF
--- a/conda/recipes/cuxfilter/recipe.yaml
+++ b/conda/recipes/cuxfilter/recipe.yaml
@@ -9,7 +9,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
 
 package:
   name: cuxfilter


### PR DESCRIPTION
This quotes `head_rev` to ensure that commits with leading zeros in the git SHA include those zeros in the output package name.

xref: https://github.com/rapidsai/build-planning/issues/176
