### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [python-build]
@@ -55,7 +56,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   wheel-build:
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,12 +49,14 @@ jobs:
           - '!CONTRIBUTING.md'
           - '!EXTERNAL_TESTS.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
         test_python:
           - '**'
           - '!.pre-commit-config.yaml'
           - '!CONTRIBUTING.md'
           - '!EXTERNAL_TESTS.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
           - '!notebooks/**'
   checks:
@@ -69,6 +71,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -77,6 +80,7 @@ jobs:
     with:
       build_type: pull-request
       run_codecov: false
+      script: ci/test_python.sh
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -87,7 +91,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/test_notebooks.sh"
+      script: "ci/test_notebooks.sh"
   docs-build:
     needs: conda-python-build
     secrets: inherit
@@ -97,7 +101,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
   wheel-build:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -29,4 +29,4 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "./ci/test_external.sh ${{ inputs.external-project || 'all' }} ${{ inputs.pr_number }}"
+      script: "./ci/test_external.sh ${{ inputs.external-project || 'all' }} ${{ inputs.pr_number }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,6 +7,7 @@ package_name="cuxfilter"
 package_dir="python"
 
 source rapids-date-string
+source rapids-init-pip
 
 rapids-generate-version > ./VERSION
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,6 +3,8 @@
 
 set -eou pipefail
 
+source rapids-init-pip
+
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 CUXFILTER_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuxfilter_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
 


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/build-planning/issues/178

* prevents triggering expensive CI jobs based on PRs modifying `ci/release/update-version.sh`

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`