### PR TITLE
Drop unneeded cuSpatial dependency

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -12,7 +12,6 @@ dependencies:
 - cudf==25.8.*,>=0.0.0a0
 - cugraph==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
-- cuspatial==25.8.*,>=0.0.0a0
 - dask-cuda==25.8.*,>=0.0.0a0
 - dask-cudf==25.8.*,>=0.0.0a0
 - datashader>=0.15

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -12,7 +12,6 @@ dependencies:
 - cudf==25.8.*,>=0.0.0a0
 - cugraph==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
-- cuspatial==25.8.*,>=0.0.0a0
 - dask-cuda==25.8.*,>=0.0.0a0
 - dask-cudf==25.8.*,>=0.0.0a0
 - datashader>=0.15

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -207,7 +207,6 @@ dependencies:
         packages:
           - &cudf_unsuffixed cudf==25.8.*,>=0.0.0a0
           - cupy>=12.0.0
-          - &cuspatial_unsuffixed cuspatial==25.8.*,>=0.0.0a0
           - &dask_cudf_unsuffixed dask-cudf==25.8.*,>=0.0.0a0
           - nodejs>=18
           - libwebp-base


### PR DESCRIPTION
Previously cuSpatial was a dependency of cuxfilter. However the logic was rewritten to drop cuSpatial and drop the dependency in PR ( https://github.com/rapidsai/cuxfilter/pull/681 ) as part of 25.06. However a few cuSpatial references were either missed or snuck back in 25.08. So this cleans them up