### PR TITLE
Drop one more `cuspatial` reference

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -219,7 +219,6 @@ dependencies:
             packages:
               - cudf-cu12==25.8.*,>=0.0.0a0
               - &cupy_cu12 cupy-cuda12x>=12.0.0
-              - cuspatial-cu12==25.8.*,>=0.0.0a0
               - dask-cudf-cu12==25.8.*,>=0.0.0a0
           - matrix:
               cuda: "12.*"


### PR DESCRIPTION
Cleaned out some remaining `cuspatial` references recently with PR: https://github.com/rapidsai/cuxfilter/pull/700

Found we missed one. Removing that here