### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For the nightly version of `cuxfilter`:
 ```bash
 # for CUDA 12
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
-    cuxfilter=25.08 python=3.13 cuda-version=12.8
+    cuxfilter=25.08 python=3.13 cuda-version=12.9
 
 # for CUDA 11
 conda install -c rapidsai-nightly -c conda-forge -c nvidia \
@@ -168,7 +168,7 @@ For the stable version of `cuxfilter`:
 ```bash
 # for CUDA 12
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cuxfilter python=3.13 cuda-version=12.8
+    cuxfilter python=3.13 cuda-version=12.9
 
 # for CUDA 11
 conda install -c rapidsai -c conda-forge -c nvidia \

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
 - bokeh>=3.1,<=3.6.3
 - bokeh_sampledata
-- cuda-version=12.8
+- cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
 - cugraph==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
@@ -45,4 +45,4 @@ dependencies:
 - sphinx>=8.0.0,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
-name: all_cuda-128_arch-aarch64
+name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
 - bokeh>=3.1,<=3.6.3
 - bokeh_sampledata
-- cuda-version=12.8
+- cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
 - cugraph==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
@@ -45,4 +45,4 @@ dependencies:
 - sphinx>=8.0.0,<8.2.0
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
-name: all_cuda-128_arch-x86_64
+name: all_cuda-129_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64, aarch64]
     includes:
       - build_wheels

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -9,7 +9,7 @@ For the most customized way of installing RAPIDS and cuxfilter, visit the select
 
     # for CUDA 12
     conda install -c rapidsai -c conda-forge -c nvidia \
-        cuxfilter=25.08 python=3.10 cuda-version=12.8
+        cuxfilter=25.08 python=3.10 cuda-version=12.9
 
     # for CUDA 11
     conda install -c rapidsai -c conda-forge -c nvidia \


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.