### PR TITLE
Pin Holoviews pre-1.21.0

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - datashader>=0.15
 - geopandas>=0.11.0
-- holoviews>=1.16.0
+- holoviews>=1.16.0,<1.21.0a0
 - ipykernel
 - ipython
 - jupyter-server-proxy

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - datashader>=0.15
 - geopandas>=0.11.0
-- holoviews>=1.16.0
+- holoviews>=1.16.0,<1.21.0a0
 - ipykernel
 - ipython
 - jupyter-server-proxy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -197,7 +197,7 @@ dependencies:
           - datashader>=0.15
           - geopandas>=0.11.0
           - shapely<2.1.0
-          - holoviews>=1.16.0
+          - holoviews>=1.16.0,<1.21.0a0
           - jupyter-server-proxy
           - numba>=0.59.1,<0.62.0a0
           - numpy>=1.23,<3.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -135,6 +135,7 @@ dependencies:
         packages:
           - bokeh>=3.1,<=3.6.3
           - bokeh_sampledata
+          - &holoviews holoviews>=1.16.0,<1.21.0a0
           - ipykernel
           - ipython
           - jupyter_sphinx
@@ -197,7 +198,7 @@ dependencies:
           - datashader>=0.15
           - geopandas>=0.11.0
           - shapely<2.1.0
-          - holoviews>=1.16.0,<1.21.0a0
+          - *holoviews
           - jupyter-server-proxy
           - numba>=0.59.1,<0.62.0a0
           - numpy>=1.23,<3.0a0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "dask-cudf==25.8.*,>=0.0.0a0",
     "datashader>=0.15",
     "geopandas>=0.11.0",
-    "holoviews>=1.16.0",
+    "holoviews>=1.16.0,<1.21.0a0",
     "jupyter-server-proxy",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 [build-system]
 build-backend = "rapids_build_backend.build"


### PR DESCRIPTION
The nightly builds on cuxfilter started failing 5 days ago. This lines up with when Holoviews 1.21.0 was released. Pin to Holoviews pre-1.21.0 as a temporary measure to clear up CI.