### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/cuxfilter/recipe.yaml
+++ b/conda/recipes/cuxfilter/recipe.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - cuda-version =${{ cuda_version }}
     - python =${{ py_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - setuptools
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -187,7 +187,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
           - setuptools
   run:
     common:


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
