### PR TITLE
update dependencies: numba (>= 0.60.0)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nodejs>=18
 - notebook>=0.5.0
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nodejs>=18
 - notebook>=0.5.0
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nodejs>=18
 - notebook>=0.5.0
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nodejs>=18
 - notebook>=0.5.0
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - packaging

--- a/conda/recipes/cuxfilter/recipe.yaml
+++ b/conda/recipes/cuxfilter/recipe.yaml
@@ -42,7 +42,7 @@ requirements:
     - jupyter-server-proxy
     - libwebp-base
     - nodejs >=14
-    - numba >=0.59.1,<0.62.0a0
+    - numba >=0.60.0,<0.62.0a0
     - numba-cuda >=0.19.1,<0.20.0a0
     - numpy >=1.23,<3.0a0
     - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -201,7 +201,7 @@ dependencies:
           - shapely<2.1.0
           - *holoviews
           - jupyter-server-proxy
-          - numba>=0.59.1,<0.62.0a0
+          - numba>=0.60.0,<0.62.0a0
           - numpy>=1.23,<3.0a0
           - packaging
           - panel>=1.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "holoviews>=1.16.0,<1.21.0a0",
     "jupyter-server-proxy",
     "numba-cuda[cu13]>=0.19.1,<0.20.0a0",
-    "numba>=0.59.1,<0.62.0a0",
+    "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "packaging",
     "panel>=1.0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/214, updating pins to match the rest of RAPIDS:

* numba: `>=0.60.0,<0.62.0a0`

## Notes for Reviewers

### Benefits of these changes

This tighter `numba` pin is already anyway constraining this project because `cuxfilter` depend on `cudf`, so this change should have 0 effect on this project's current state.

Making the pin explicit makes it a bit easier to do all-of-RAPIDS updates in the future if needed.