### PR TITLE
Use main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - "branch-*"
+      - "main"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:


### PR DESCRIPTION
## Description
Supports rollout of new branching strategy. https://docs.rapids.ai/notices/rsn0047/

xref: https://github.com/rapidsai/build-planning/issues/224
