### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ cd $CUXFILTER_HOME
 - Create the conda development environment `cuxfilter_dev`:
 ```bash
 # create the conda environment (assuming in base `cuxfilter` directory)
-conda env create --name cuxfilter_dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+conda env create --name cuxfilter_dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 # activate the environment
 source activate cuxfilter_dev
 ```


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.