### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ concurrency:
 permissions: {}
 jobs:
   python-build:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -49,7 +49,9 @@ jobs:
       pull-requests: read
   upload-conda:
     needs: [python-build]
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -65,7 +67,7 @@ jobs:
   docs-build:
     if: github.ref_type == 'branch'
     needs: python-build
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       arch: "amd64"
@@ -83,7 +85,7 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -102,7 +104,9 @@ jobs:
       pull-requests: read
   wheel-publish:
     needs: wheel-build
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,4 @@
 name: build
-
 on:
   push:
     branches:
@@ -27,11 +26,10 @@ on:
         description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   python-build:
     secrets: inherit
@@ -43,6 +41,12 @@ jobs:
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       pure-conda: cuda_major
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   upload-conda:
     needs: [python-build]
     secrets: inherit
@@ -52,6 +56,12 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   docs-build:
     if: github.ref_type == 'branch'
     needs: python-build
@@ -66,6 +76,12 @@ jobs:
       node_type: "gpu-l4-latest-1"
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   wheel-build:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
@@ -78,6 +94,12 @@ jobs:
       package-name: cuxfilter
       package-type: python
       pure-wheel: true
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   wheel-publish:
     needs: wheel-build
     secrets: inherit
@@ -90,3 +112,9 @@ jobs:
       package-name: cuxfilter
       package-type: python
       publish-wheel-search-key: "cuxfilter_wheel"
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,8 @@
 name: "Pull Request Labeler"
-on:
+# `zizmor` always flags these triggers because they are easy to use
+# incorrectly. These usages are ok and don't execute any PR-specific
+# code (and so aren't susceptible to exploits from forked PRs)
+on: # zizmor: ignore[dangerous-triggers]
   - pull_request_target
 permissions: {}
 jobs:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
  triage:
    runs-on: ubuntu-latest
    steps:
-   - uses: actions/labeler@v5
+   - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
      with:
        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,11 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
-
+  - pull_request_target
+permissions: {}
 jobs:
- triage:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-     with:
-       repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/new-issues-to-triage-projects.yml
+++ b/.github/workflows/new-issues-to-triage-projects.yml
@@ -1,35 +1,33 @@
 name: Auto Assign New Issues to Triage Project
-
 on:
   issues:
     types: [opened]
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+permissions: {}
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
     name: Assign to New Issues to Triage Project
     steps:
-    - name: Process bug issues
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-      if: contains(github.event.issue.labels.*.name, 'bug') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/2
-        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
-    - name: Process feature issues
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-      if: contains(github.event.issue.labels.*.name, 'feature request') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/1
-        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
-    - name: Process other issues
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-      if: contains(github.event.issue.labels.*.name, '? - Needs Triage') && (!contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'feature request'))
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/7
-        GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
+      - name: Process bug issues
+        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+        if: contains(github.event.issue.labels.*.name, 'bug') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/2
+          GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
+      - name: Process feature issues
+        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+        if: contains(github.event.issue.labels.*.name, 'feature request') && contains(github.event.issue.labels.*.name, '? - Needs Triage')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/1
+          GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'
+      - name: Process other issues
+        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+        if: contains(github.event.issue.labels.*.name, '? - Needs Triage') && (!contains(github.event.issue.labels.*.name, 'bug') && !contains(github.event.issue.labels.*.name, 'feature request'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PROJECT_URL: https://github.com/rapidsai/cuxfilter/projects/7
+          GITHUB_PROJECT_COLUMN_NAME: 'Needs prioritizing'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,6 @@ jobs:
       - wheel-build
       - wheel-tests
       - telemetry-setup
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     if: always()
     with:
@@ -39,7 +38,6 @@ jobs:
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   changed-files:
-    secrets: inherit
     needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
     with:
@@ -135,7 +133,6 @@ jobs:
       packages: read
       pull-requests: read
   checks:
-    secrets: inherit
     needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
@@ -160,7 +157,7 @@ jobs:
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
   conda-python-build:
     needs: checks
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
@@ -174,7 +171,7 @@ jobs:
       pull-requests: read
   conda-python-tests:
     needs: [conda-python-build, changed-files]
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
@@ -189,7 +186,7 @@ jobs:
       pull-requests: read
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
     with:
@@ -206,7 +203,7 @@ jobs:
       pull-requests: read
   docs-build:
     needs: [conda-python-build, changed-files]
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
@@ -223,7 +220,7 @@ jobs:
       pull-requests: read
   wheel-build:
     needs: checks
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
@@ -239,7 +236,7 @@ jobs:
       pull-requests: read
   wheel-tests:
     needs: [wheel-build, changed-files]
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   pr-builder:
     needs:
@@ -24,6 +25,8 @@ jobs:
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
+    permissions:
+      contents: read
   telemetry-setup:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -126,12 +129,19 @@ jobs:
           - '!conda/**'
           - '!docs/**'
           - '!notebooks/**'
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      pull-requests: read
   checks:
     secrets: inherit
     needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       ignored_pr_jobs: telemetry-summarize
+    permissions:
+      contents: read
   check-nightly-ci:
     runs-on: ubuntu-latest
     permissions:
@@ -156,6 +166,12 @@ jobs:
       build_type: pull-request
       script: ci/build_python.sh
       pure-conda: cuda_major
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -165,6 +181,12 @@ jobs:
       build_type: pull-request
       run_codecov: false
       script: ci/test_python.sh
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -176,6 +198,12 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/test_notebooks.sh"
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   docs-build:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -187,6 +215,12 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/build_docs.sh"
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   wheel-build:
     needs: checks
     secrets: inherit
@@ -197,6 +231,12 @@ jobs:
       package-name: cuxfilter
       package-type: python
       pure-wheel: true
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   wheel-tests:
     needs: [wheel-build, changed-files]
     secrets: inherit
@@ -207,6 +247,12 @@ jobs:
       script: ci/test_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Get PR Info
         id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
       - name: Check if nightly CI is passing
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -1,5 +1,4 @@
 name: GPU testing for external party dependencies
-
 on:
   workflow_dispatch:
     inputs:
@@ -12,14 +11,11 @@ on:
           - holoviews
           - all
       pr_number:
-        description: "
-          The number of the pull request to check out, else checks out default branch.
-          Will be ignored if external-project=all
-          "
+        description: " The number of the pull request to check out, else checks out default branch. Will be ignored if external-project=all "
         required: false
   schedule:
     - cron: "0 0 * * 1" # Run every Sunday evening Pacific Time (Monday 0:00 UTC)
-
+permissions: {}
 jobs:
   test-external:
     secrets: inherit
@@ -30,3 +26,9 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: "./ci/test_external.sh ${{ inputs.external-project || 'all' }} ${{ inputs.pr_number }}"
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -18,7 +18,7 @@ on:
 permissions: {}
 jobs:
   test-external:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: branch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,4 @@
 name: test
-
 on:
   workflow_dispatch:
     inputs:
@@ -21,7 +20,7 @@ on:
         description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
-
+permissions: {}
 jobs:
   conda-python-tests:
     secrets: inherit
@@ -32,6 +31,12 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   wheel-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -43,3 +48,9 @@ jobs:
       script: ci/test_wheel.sh
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]) | [.]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ on:
 permissions: {}
 jobs:
   conda-python-tests:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
@@ -38,7 +38,7 @@ jobs:
       packages: read
       pull-requests: read
   wheel-tests:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     with:
       build_type: ${{ inputs.build_type }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,5 +1,8 @@
 name: Trigger Breaking Change Notifications
-on:
+# `zizmor` always flags these triggers because they are easy to use
+# incorrectly. These usages are ok and don't execute any PR-specific
+# code (and so aren't susceptible to exploits from forked PRs)
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - closed

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,5 +1,4 @@
 name: Trigger Breaking Change Notifications
-
 on:
   pull_request_target:
     types:
@@ -7,7 +6,7 @@ on:
       - reopened
       - labeled
       - unlabeled
-
+permissions: {}
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
@@ -24,3 +23,5 @@ jobs:
       pr_author: ${{ github.event.pull_request.user.login }}
       event_action: ${{ github.event.action }}
       pr_merged: ${{ github.event.pull_request.merged }}
+    permissions:
+      contents: read

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -10,7 +10,8 @@ permissions: {}
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
-    secrets: inherit
+    secrets:
+      NV_SLACK_BREAKING_CHANGE_ALERT: ${{ secrets.NV_SLACK_BREAKING_CHANGE_ALERT }}
     uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     with:
       sender_login: ${{ github.event.sender.login }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,5 +51,9 @@ repos:
         rev: v0.10.0.1
         hooks:
           - id: shellcheck
+      - repo: https://github.com/zizmorcore/zizmor-pre-commit
+        rev: v1.24.1
+        hooks:
+          - id: zizmor
 default_language_version:
       python: python3


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275