### PR TITLE
fix(ci): add explicit `actions: write` permission for `telemetry-summarize`


### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -261,3 +261,5 @@ jobs:
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
     env:
       GH_TOKEN: ${{ github.token }}
+    permissions:
+      actions: write


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/build-planning/issues/275 we removed the default set of permissions from all workflow jobs.

The shared-action that handles telemetry cleanup is now failing because it is trying to clean up artifacts that shouldn't remain after a given workflow run.

This PR adds an explicit `actions: write` permission, to allow that action to clean up those artifacts.

xref https://github.com/rapidsai/shared-actions/issues/106
