### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - dask-cuda==26.6.*,>=0.0.0a0
 - dask-cudf==26.6.*,>=0.0.0a0
 - datashader>=0.15

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - dask-cuda==26.6.*,>=0.0.0a0
 - dask-cudf==26.6.*,>=0.0.0a0
 - datashader>=0.15

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - dask-cuda==26.6.*,>=0.0.0a0
 - dask-cudf==26.6.*,>=0.0.0a0
 - datashader>=0.15

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - dask-cuda==26.6.*,>=0.0.0a0
 - dask-cudf==26.6.*,>=0.0.0a0
 - datashader>=0.15

--- a/conda/recipes/cuxfilter/recipe.yaml
+++ b/conda/recipes/cuxfilter/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - certifi >=2026.1.4
     - cudf =${{ minor_version }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - dask-cudf =${{ minor_version }}
     - datashader >=0.15
     - geopandas >=0.11.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -268,7 +268,7 @@ dependencies:
           - requests
       - output_types: conda
         packages:
-          - &cupy_unsuffixed cupy>=13.6.0
+          - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0,!=14.1.0
           - nodejs>=18
           - numba-cuda>=0.22.2,<0.29.0
           - libwebp-base
@@ -291,11 +291,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   test_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "bokeh>=3.1,<=3.6.3",
     "certifi>=2026.1.4",
     "cudf==26.6.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "dask-cudf==26.6.*,>=0.0.0a0",
     "datashader>=0.15",
     "geopandas>=0.11.0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
