### PR TITLE
Remove numba-cuda upper bound

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba-cuda>=0.22.2,<0.29.0
+- numba-cuda>=0.22.2
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba-cuda>=0.22.2,<0.29.0
+- numba-cuda>=0.22.2
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba-cuda>=0.22.2,<0.29.0
+- numba-cuda>=0.22.2
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - nbsphinx
 - nodejs>=18
 - notebook>=0.5.0
-- numba-cuda>=0.22.2,<0.29.0
+- numba-cuda>=0.22.2
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/recipes/cuxfilter/recipe.yaml
+++ b/conda/recipes/cuxfilter/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
     - libwebp-base
     - nodejs >=14
     - numba >=0.60.0,<0.65.0
-    - numba-cuda >=0.22.2,<0.29.0
+    - numba-cuda >=0.22.2
     - numpy >=1.23,<3.0
     - packaging
     - panel >=1.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -270,7 +270,7 @@ dependencies:
         packages:
           - &cupy_unsuffixed cupy>=13.6.0,!=14.0.0,!=14.1.0
           - nodejs>=18
-          - numba-cuda>=0.22.2,<0.29.0
+          - numba-cuda>=0.22.2
           - libwebp-base
     specific:
       - output_types: [requirements, pyproject]
@@ -278,11 +278,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - numba-cuda[cu12]>=0.22.2,<0.29.0
+              - numba-cuda[cu12]>=0.22.2
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - numba-cuda[cu13]>=0.22.2,<0.29.0
+              - numba-cuda[cu13]>=0.22.2
       # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
       #       other packages with -cu{nn}x suffixes in this file.
       #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "geopandas>=0.11.0",
     "holoviews>=1.16.0,<1.21.0",
     "jupyter-server-proxy",
-    "numba-cuda[cu13]>=0.22.2,<0.29.0",
+    "numba-cuda[cu13]>=0.22.2",
     "numba>=0.60.0,<0.65.0",
     "numpy>=1.23,<3.0",
     "packaging",


### PR DESCRIPTION
This PR removes the upper bound on the `numba-cuda` dependency,
leaving only the existing lower bound pins in place.

<hr>

Part of this work:

* https://github.com/rapidsai/build-planning/issues/245